### PR TITLE
Upgrade Node.js from 20 to 22 (Active LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - uses: pnpm/action-setup@v4
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/apps/admin-app/Dockerfile
+++ b/apps/admin-app/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Builder
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 RUN corepack enable
 
 WORKDIR /app
@@ -26,7 +26,7 @@ RUN pnpm --filter admin-app build
 RUN pnpm --filter admin-app build:server
 
 # Stage 2: Runtime
-FROM node:20-alpine AS runtime
+FROM node:22-alpine AS runtime
 RUN apk update && apk upgrade --no-cache
 RUN corepack enable
 

--- a/apps/map-client/Dockerfile
+++ b/apps/map-client/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Builder
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 RUN corepack enable
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Upgrades Docker base images from `node:20-alpine` to `node:22-alpine` in both app Dockerfiles
- Upgrades CI workflows (ci, docs, release) to use Node 22
- Replaces dependabot PRs #27 and #28 which proposed Node 25 (non-LTS)

Node 22 is the current Active LTS release, supported until October 2027.

## Test plan
- [x] CI passes with Node 22
- [x] Docker builds succeed for both admin-app and map-client
- [x] Apps start and function correctly in containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)