### PR TITLE
Upgrade Zod from v3 to v4

### DIFF
--- a/apps/admin-app/package.json
+++ b/apps/admin-app/package.json
@@ -33,7 +33,7 @@
     "react-map-gl": "^7.1.7",
     "react-router-dom": "^6.28.0",
     "shp-write": "^0.3.2",
-    "zod": "^3.25.76"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0-beta.10",

--- a/apps/admin-app/server/index.ts
+++ b/apps/admin-app/server/index.ts
@@ -333,7 +333,7 @@ app.post('/api/configs', requireAuth, async (req, res) => {
   if (config) {
     const validation = safeValidateMapConfig(config);
     if (!validation.success) {
-      res.status(400).json({ error: 'Invalid config', details: validation.error.errors });
+      res.status(400).json({ error: 'Invalid config', details: validation.error.issues });
       return;
     }
   }
@@ -366,7 +366,7 @@ app.put('/api/configs/:id', requireAuth, async (req, res) => {
   if (config) {
     const validation = safeValidateMapConfig(config);
     if (!validation.success) {
-      res.status(400).json({ error: 'Invalid config', details: validation.error.errors });
+      res.status(400).json({ error: 'Invalid config', details: validation.error.issues });
       return;
     }
   }

--- a/apps/admin-app/src/pages/ConfigWizardPage.tsx
+++ b/apps/admin-app/src/pages/ConfigWizardPage.tsx
@@ -184,7 +184,7 @@ export function ConfigWizardPage() {
 
     const validation = safeValidateMapConfig(assembledConfig);
     if (!validation.success) {
-      setValidationErrors(validation.error.errors.map(e => `${e.path.join('.')}: ${e.message}`));
+      setValidationErrors(validation.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`));
       setSaving(false);
       return;
     }

--- a/apps/map-client/package.json
+++ b/apps/map-client/package.json
@@ -26,7 +26,7 @@
     "react-icons": "^5.0.0",
     "react-map-gl": "^7.1.7",
     "shp-write": "^0.3.2",
-    "zod": "^3.25.76",
+    "zod": "^4.3.6",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/apps/map-client/src/App.tsx
+++ b/apps/map-client/src/App.tsx
@@ -45,7 +45,7 @@ function App() {
         const result = safeValidateMapConfig(raw);
         if (!result.success) {
           setValidationError(
-            `Config validation failed: ${result.error.errors.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ')}`
+            `Config validation failed: ${result.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ')}`
           );
           return;
         }
@@ -64,7 +64,7 @@ function App() {
       const result = safeValidateMapConfig(raw);
       if (!result.success) {
         setValidationError(
-          `Config validation failed: ${result.error.errors.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ')}`
+          `Config validation failed: ${result.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ')}`
         );
         return;
       }

--- a/apps/map-client/src/hooks/useMapUrlState.ts
+++ b/apps/map-client/src/hooks/useMapUrlState.ts
@@ -28,7 +28,7 @@ const searchFilterValueSchema = z.union([
 const stateParsers = {
   layers: parseAsArrayOf(parseAsString),
   basemap: parseAsString,
-  filters: parseAsJson(z.record(z.record(searchFilterValueSchema))),
+  filters: parseAsJson(z.record(z.string(), z.record(z.string(), searchFilterValueSchema))),
 };
 
 export function useMapUrlState() {

--- a/packages/map-ui-lib/package.json
+++ b/packages/map-ui-lib/package.json
@@ -89,7 +89,7 @@
     "@turf/buffer": "^7.3.4",
     "@turf/helpers": "^7.3.4",
     "@turf/length": "^7.3.4",
-    "zod": "^3.24.1"
+    "zod": "^4.3.6"
   },
   "optionalDependencies": {
     "@ngageoint/geopackage": "^4.2.0",

--- a/packages/map-ui-lib/src/components/ConfigPreview/ConfigPreview.tsx
+++ b/packages/map-ui-lib/src/components/ConfigPreview/ConfigPreview.tsx
@@ -29,7 +29,7 @@ export function ConfigPreview({ config }: ConfigPreviewProps) {
             Validation Errors
           </p>
           <ul className="mapui:m-0 mapui:list-none mapui:flex mapui:flex-col mapui:gap-1 mapui:p-0">
-            {result.error.errors.map((err, i) => (
+            {result.error.issues.map((err, i) => (
               <li key={i} className="mapui:flex mapui:flex-col mapui:gap-0.5">
                 <span className="mapui:font-mono mapui:text-xs mapui:text-red-600">
                   {err.path.join(' > ') || 'root'}

--- a/packages/map-ui-lib/src/schemas/config.ts
+++ b/packages/map-ui-lib/src/schemas/config.ts
@@ -286,7 +286,7 @@ export const PropertyDisplayConfigSchema = z.record(z.string(), PropertyDisplayS
 
 export const FilterConfigSchema = z.object({
   properties: z
-    .record(z.union([z.string(), z.number(), z.boolean(), z.array(z.string())]))
+    .record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.array(z.string())]))
     .optional(),
   bbox: z.tuple([z.number(), z.number(), z.number(), z.number()]).optional(),
   datetime: z.string().optional(),
@@ -513,10 +513,10 @@ export const ImageryLayerConfigSchema = z.object({
 }).superRefine((data, ctx) => {
   if (!data.tileUrlTemplate) {
     if (!data.sourceId) {
-      ctx.addIssue({ code: z.ZodIssueCode.too_small, minimum: 1, type: 'string', inclusive: true, path: ['sourceId'], message: 'Source is required when not using a custom tile URL' });
+      ctx.addIssue({ code: 'custom', path: ['sourceId'], message: 'Source is required when not using a custom tile URL' });
     }
     if (!data.collection) {
-      ctx.addIssue({ code: z.ZodIssueCode.too_small, minimum: 1, type: 'string', inclusive: true, path: ['collection'], message: 'Collection is required when not using a custom tile URL' });
+      ctx.addIssue({ code: 'custom', path: ['collection'], message: 'Collection is required when not using a custom tile URL' });
     }
   }
 });
@@ -529,7 +529,20 @@ export const MapConfigSchema = z.object({
   imageryLayers: z.array(ImageryLayerConfigSchema).optional(),
   basemaps: z.array(BasemapConfigSchema).min(1),
   sprites: z.array(SpriteSourceSchema).optional(),
-  ui: UIConfigSchema.default({}),
+  ui: UIConfigSchema.default({
+    showLayerPanel: true,
+    showLegend: true,
+    showBasemapSwitcher: true,
+    showSearchPanel: false,
+    showCoordinateDisplay: true,
+    showFeatureDetail: true,
+    showFeatureTooltip: true,
+    showExportButton: true,
+    showLegendOpacity: false,
+    showMeasureTool: false,
+    showSelectionTool: false,
+    showImageryPanel: false,
+  }),
   initialView: ViewConfigSchema,
   branding: BrandingConfigSchema.optional(),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.0-beta.10
@@ -188,8 +188,8 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.3
         version: 5.0.11(@types/react@18.3.28)(react@18.3.1)
@@ -231,8 +231,8 @@ importers:
         specifier: ^7.3.4
         version: 7.3.4
       zod:
-        specifier: ^3.24.1
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^3.2.2
@@ -4385,8 +4385,8 @@ packages:
   zarrita@0.6.1:
     resolution: {integrity: sha512-YOMTW8FT55Rz+vadTIZeOFZ/F2h4svKizyldvPtMYSxPgSNcRkOzkxCsWpIWlWzB1I/LmISmi0bEekOhLlI+Zw==}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zstddec@0.2.0:
     resolution: {integrity: sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==}
@@ -8703,7 +8703,7 @@ snapshots:
       numcodecs: 0.3.2
     optional: true
 
-  zod@3.25.76: {}
+  zod@4.3.6: {}
 
   zstddec@0.2.0:
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades Zod from v3 to v4.3.6 across all three workspaces
- Fixes breaking API changes:
  - `z.record()` now requires explicit key type argument
  - `ZodError.errors` → `ZodError.issues`
  - `z.ZodIssueCode` removed; using string literal `'custom'` instead
  - `z.object().default({})` requires full default values
- Replaces dependabot PR #36

## Test plan
- [x] `pnpm build` succeeds across all workspaces
- [x] `pnpm test` — 279 tests pass
- [x] Manual: verify config validation in admin app
- [x] Manual: verify URL state parsing in map client

🤖 Generated with [Claude Code](https://claude.com/claude-code)