### PR TITLE
feat: wire Groups tab into DataDrivenColorEditor (Phase 4)

### DIFF
--- a/.changeset/category-group-filtering.md
+++ b/.changeset/category-group-filtering.md
@@ -1,0 +1,12 @@
+---
+"@ogc-maps/storybook-components": minor
+---
+
+Add category-based grouping and bulk filtering capabilities.
+
+- New `CategoryMatchRuleSchema` and `CategoryGroupSchema` Zod schemas for defining named groups with rule-based matching (values list, pattern operators, or catch-all)
+- New `CategorySearchFieldSchema` search field type that surfaces group names in the SearchPanel dropdown and compiles to CQL2 on selection
+- New `categoryGroupToCql2` and `categoryGroupsToMaplibreExpression` utility functions for compiling groups to CQL2 filters and MapLibre `case` expressions
+- New `CategoryGroupEditor` React component for admin UIs to configure groups (values picker, pattern operators, reorder)
+- `LayerConfig` gains an optional `categoryGroups` field for reusable group definitions
+- `fromStructuredFilters` now resolves category field selections to their CQL2 expressions automatically

--- a/packages/map-ui-lib/src/components/CategoryGroupEditor/CategoryGroupEditor.stories.tsx
+++ b/packages/map-ui-lib/src/components/CategoryGroupEditor/CategoryGroupEditor.stories.tsx
@@ -1,0 +1,180 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import type { CategoryGroup } from '../../types';
+import { CategoryGroupEditor } from './CategoryGroupEditor';
+
+const meta: Meta<typeof CategoryGroupEditor> = {
+  title: 'Admin/CategoryGroupEditor',
+  component: CategoryGroupEditor,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Configure named category groups with rule-based matching. Groups compile to CQL2 filters and MapLibre case expressions, avoiding the need to manually enumerate thousands of values.',
+      },
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof CategoryGroupEditor>;
+
+export const Empty: Story = {
+  render: () => {
+    const [groups, setGroups] = useState<CategoryGroup[]>([]);
+    return (
+      <div className="mapui:max-w-lg mapui:p-4">
+        <CategoryGroupEditor groups={groups} onGroupsChange={setGroups} />
+        <pre className="mapui:mt-4 mapui:rounded mapui:bg-slate-100 mapui:p-3 mapui:text-xs">
+          {JSON.stringify(groups, null, 2)}
+        </pre>
+      </div>
+    );
+  },
+};
+
+/** Owner location grouping — Colorado vs. Out of State. */
+export const OwnerLocation: Story = {
+  render: () => {
+    const [groups, setGroups] = useState<CategoryGroup[]>([
+      {
+        id: 'co',
+        label: 'Colorado Owners',
+        color: '#3b82f6',
+        matchRule: { kind: 'values', values: ['CO'] },
+      },
+      {
+        id: 'out-of-state',
+        label: 'Out of State Owners',
+        color: '#f59e0b',
+        matchRule: { kind: 'pattern', operator: 'not_equals', pattern: 'CO' },
+      },
+      {
+        id: 'unknown',
+        label: 'Unknown',
+        color: '#94a3b8',
+        matchRule: { kind: 'catchAll' },
+      },
+    ]);
+
+    const availableValues = [
+      'AK', 'AL', 'AR', 'AZ', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
+      'HI', 'IA', 'ID', 'IL', 'IN', 'KS', 'KY', 'LA', 'MA', 'MD',
+      'ME', 'MI', 'MN', 'MO', 'MS', 'MT', 'NC', 'ND', 'NE', 'NH',
+      'NJ', 'NM', 'NV', 'NY', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC',
+      'SD', 'TN', 'TX', 'UT', 'VA', 'VT', 'WA', 'WI', 'WV', 'WY',
+    ];
+
+    return (
+      <div className="mapui:max-w-lg mapui:p-4">
+        <h4 className="mapui:mb-2 mapui:text-sm mapui:font-semibold mapui:text-slate-700">
+          Owner State Groups
+        </h4>
+        <CategoryGroupEditor
+          groups={groups}
+          onGroupsChange={setGroups}
+          availableValues={availableValues}
+        />
+        <pre className="mapui:mt-4 mapui:rounded mapui:bg-slate-100 mapui:p-3 mapui:text-xs">
+          {JSON.stringify(groups, null, 2)}
+        </pre>
+      </div>
+    );
+  },
+};
+
+/** Owner name grouping — LLC, Trust, individual owners. Handles ~21,000 unique values via patterns. */
+export const OwnerNamePatterns: Story = {
+  render: () => {
+    const [groups, setGroups] = useState<CategoryGroup[]>([
+      {
+        id: 'llc',
+        label: 'LLC / Corp',
+        color: '#ef4444',
+        matchRule: { kind: 'pattern', operator: 'contains', pattern: 'LLC' },
+      },
+      {
+        id: 'trust',
+        label: 'Trust',
+        color: '#8b5cf6',
+        matchRule: { kind: 'pattern', operator: 'contains', pattern: 'TRUST' },
+      },
+      {
+        id: 'inc',
+        label: 'Incorporated',
+        color: '#f97316',
+        matchRule: { kind: 'pattern', operator: 'contains', pattern: 'INC' },
+      },
+      {
+        id: 'individual',
+        label: 'Individual Owners',
+        color: '#22c55e',
+        matchRule: { kind: 'catchAll' },
+      },
+    ]);
+
+    return (
+      <div className="mapui:max-w-lg mapui:p-4">
+        <h4 className="mapui:mb-2 mapui:text-sm mapui:font-semibold mapui:text-slate-700">
+          Owner Name Groups
+        </h4>
+        <p className="mapui:mb-3 mapui:text-xs mapui:text-slate-500">
+          Pattern rules handle ~21,000 unique owner names without manual selection.
+        </p>
+        <CategoryGroupEditor groups={groups} onGroupsChange={setGroups} />
+        <pre className="mapui:mt-4 mapui:rounded mapui:bg-slate-100 mapui:p-3 mapui:text-xs">
+          {JSON.stringify(groups, null, 2)}
+        </pre>
+      </div>
+    );
+  },
+};
+
+/** Demonstrates multi-value selection from a known list (e.g. county parcels by zone type). */
+export const MultiValueGroup: Story = {
+  render: () => {
+    const [groups, setGroups] = useState<CategoryGroup[]>([
+      {
+        id: 'residential',
+        label: 'Residential',
+        color: '#84cc16',
+        matchRule: { kind: 'values', values: ['SF', 'MF', 'MH', 'MFR'] },
+      },
+      {
+        id: 'commercial',
+        label: 'Commercial',
+        color: '#0ea5e9',
+        matchRule: { kind: 'values', values: ['C1', 'C2', 'C3', 'CH'] },
+      },
+      {
+        id: 'industrial',
+        label: 'Industrial',
+        color: '#f59e0b',
+        matchRule: { kind: 'values', values: ['I1', 'I2', 'I3'] },
+      },
+      {
+        id: 'other',
+        label: 'Other / Unzoned',
+        color: '#94a3b8',
+        matchRule: { kind: 'catchAll' },
+      },
+    ]);
+
+    const availableValues = ['SF', 'MF', 'MH', 'MFR', 'C1', 'C2', 'C3', 'CH', 'I1', 'I2', 'I3', 'AG', 'PF', 'OS'];
+
+    return (
+      <div className="mapui:max-w-lg mapui:p-4">
+        <h4 className="mapui:mb-2 mapui:text-sm mapui:font-semibold mapui:text-slate-700">
+          Zoning Groups
+        </h4>
+        <CategoryGroupEditor
+          groups={groups}
+          onGroupsChange={setGroups}
+          availableValues={availableValues}
+        />
+        <pre className="mapui:mt-4 mapui:rounded mapui:bg-slate-100 mapui:p-3 mapui:text-xs">
+          {JSON.stringify(groups, null, 2)}
+        </pre>
+      </div>
+    );
+  },
+};

--- a/packages/map-ui-lib/src/components/CategoryGroupEditor/CategoryGroupEditor.tsx
+++ b/packages/map-ui-lib/src/components/CategoryGroupEditor/CategoryGroupEditor.tsx
@@ -1,0 +1,362 @@
+import { useState } from 'react';
+import type { CategoryGroup, CategoryMatchRule } from '../../types';
+import { ColorPicker } from '../admin/ColorPicker';
+import { generateId } from '../../utils/id';
+import { getColorFromPalette } from '../../utils/colorPalettes';
+
+export interface CategoryGroupEditorProps {
+  /** Ordered list of category groups. */
+  groups: CategoryGroup[];
+  /** Called when the groups array changes. */
+  onGroupsChange: (groups: CategoryGroup[]) => void;
+  /** Optional hint values (e.g. distinct property values) for the values picker. */
+  availableValues?: string[];
+}
+
+const PATTERN_OPERATORS: Array<{ value: string; label: string }> = [
+  { value: 'contains',     label: 'contains' },
+  { value: 'not_contains', label: 'does not contain' },
+  { value: 'startsWith',   label: 'starts with' },
+  { value: 'endsWith',     label: 'ends with' },
+  { value: 'equals',       label: 'equals' },
+  { value: 'not_equals',   label: 'not equals' },
+];
+
+const inputCls =
+  'mapui:rounded mapui:border mapui:border-slate-300 mapui:px-2 mapui:py-1 mapui:text-sm mapui:outline-none focus:mapui:border-blue-500 focus:mapui:ring-1 focus:mapui:ring-blue-500';
+const btnCls =
+  'mapui:cursor-pointer mapui:rounded mapui:border mapui:border-slate-300 mapui:bg-white mapui:px-2 mapui:py-1 mapui:text-xs mapui:text-slate-700 hover:mapui:bg-slate-50';
+const dangerBtnCls =
+  'mapui:cursor-pointer mapui:rounded mapui:border mapui:border-red-200 mapui:bg-white mapui:px-2 mapui:py-1 mapui:text-xs mapui:text-red-600 hover:mapui:bg-red-50';
+
+function matchRuleSummary(rule: CategoryMatchRule): string {
+  if (rule.kind === 'catchAll') return 'Everything else';
+  if (rule.kind === 'values') {
+    if (rule.values.length === 0) return 'No values selected';
+    if (rule.values.length <= 3) return `= ${rule.values.join(', ')}`;
+    return `${rule.values.slice(0, 3).join(', ')} +${rule.values.length - 3} more`;
+  }
+  const opLabel = PATTERN_OPERATORS.find((o) => o.value === rule.operator)?.label ?? rule.operator;
+  return `${opLabel} "${rule.pattern}"`;
+}
+
+interface GroupRowProps {
+  group: CategoryGroup;
+  index: number;
+  totalGroups: number;
+  availableValues?: string[];
+  onUpdate: (updated: CategoryGroup) => void;
+  onRemove: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+}
+
+function GroupRow({
+  group,
+  index,
+  totalGroups,
+  availableValues = [],
+  onUpdate,
+  onRemove,
+  onMoveUp,
+  onMoveDown,
+}: GroupRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [valuesInput, setValuesInput] = useState('');
+
+  const rule = group.matchRule;
+  const ruleKind = rule.kind;
+
+  const setRuleKind = (kind: 'values' | 'pattern' | 'catchAll') => {
+    let matchRule: CategoryMatchRule;
+    if (kind === 'values') matchRule = { kind: 'values', values: [] };
+    else if (kind === 'pattern') matchRule = { kind: 'pattern', operator: 'contains', pattern: '' };
+    else matchRule = { kind: 'catchAll' };
+    onUpdate({ ...group, matchRule });
+  };
+
+  const addValue = (val: string) => {
+    if (rule.kind !== 'values') return;
+    const trimmed = val.trim();
+    if (!trimmed || rule.values.includes(trimmed)) return;
+    onUpdate({ ...group, matchRule: { ...rule, values: [...rule.values, trimmed] } });
+    setValuesInput('');
+  };
+
+  const removeValue = (val: string | number) => {
+    if (rule.kind !== 'values') return;
+    onUpdate({ ...group, matchRule: { ...rule, values: rule.values.filter((v) => v !== val) } });
+  };
+
+  return (
+    <div className="mapui:rounded mapui:border mapui:border-slate-200 mapui:bg-white">
+      {/* Row header */}
+      <div className="mapui:flex mapui:items-center mapui:gap-2 mapui:p-2">
+        {/* Reorder */}
+        <div className="mapui:flex mapui:flex-col mapui:gap-0.5">
+          <button
+            type="button"
+            onClick={onMoveUp}
+            disabled={index === 0}
+            className="mapui:cursor-pointer mapui:rounded mapui:border-none mapui:bg-transparent mapui:p-0 mapui:text-slate-400 disabled:mapui:opacity-30 hover:mapui:text-slate-700"
+            aria-label="Move group up"
+          >
+            ▲
+          </button>
+          <button
+            type="button"
+            onClick={onMoveDown}
+            disabled={index === totalGroups - 1}
+            className="mapui:cursor-pointer mapui:rounded mapui:border-none mapui:bg-transparent mapui:p-0 mapui:text-slate-400 disabled:mapui:opacity-30 hover:mapui:text-slate-700"
+            aria-label="Move group down"
+          >
+            ▼
+          </button>
+        </div>
+
+        {/* Color swatch */}
+        <span
+          className="mapui:h-5 mapui:w-5 mapui:shrink-0 mapui:rounded-sm mapui:border mapui:border-slate-200"
+          style={{ backgroundColor: group.color }}
+        />
+
+        {/* Label + rule summary */}
+        <button
+          type="button"
+          onClick={() => setExpanded((e) => !e)}
+          className="mapui:min-w-0 mapui:flex-1 mapui:cursor-pointer mapui:rounded mapui:border-none mapui:bg-transparent mapui:px-0 mapui:py-0 mapui:text-left mapui:text-sm mapui:text-slate-700 hover:mapui:text-slate-900"
+        >
+          <span className="mapui:font-medium">{group.label || 'Unnamed group'}</span>
+          <span className="mapui:ml-2 mapui:text-xs mapui:text-slate-400">{matchRuleSummary(group.matchRule)}</span>
+        </button>
+
+        <button type="button" onClick={onRemove} className={dangerBtnCls} aria-label="Remove group">
+          ×
+        </button>
+      </div>
+
+      {/* Expanded editor */}
+      {expanded && (
+        <div className="mapui:flex mapui:flex-col mapui:gap-3 mapui:border-t mapui:border-slate-100 mapui:p-3">
+          {/* Label */}
+          <div className="mapui:flex mapui:items-center mapui:gap-2">
+            <label className="mapui:w-16 mapui:shrink-0 mapui:text-xs mapui:text-slate-600">Label</label>
+            <input
+              type="text"
+              value={group.label}
+              onChange={(e) => onUpdate({ ...group, label: e.target.value })}
+              className={`${inputCls} mapui:flex-1`}
+              placeholder="Group name"
+            />
+          </div>
+
+          {/* Color */}
+          <div className="mapui:flex mapui:items-center mapui:gap-2">
+            <label className="mapui:w-16 mapui:shrink-0 mapui:text-xs mapui:text-slate-600">Color</label>
+            <ColorPicker
+              value={group.color}
+              onChange={(color) => onUpdate({ ...group, color })}
+              label={`Color for ${group.label}`}
+            />
+          </div>
+
+          {/* Rule type toggle */}
+          <div className="mapui:flex mapui:items-center mapui:gap-2">
+            <label className="mapui:w-16 mapui:shrink-0 mapui:text-xs mapui:text-slate-600">Match by</label>
+            <div className="mapui:flex mapui:overflow-hidden mapui:rounded mapui:border mapui:border-slate-300">
+              {(['values', 'pattern', 'catchAll'] as const).map((kind) => (
+                <button
+                  key={kind}
+                  type="button"
+                  onClick={() => setRuleKind(kind)}
+                  className={[
+                    'mapui:cursor-pointer mapui:border-0 mapui:px-2 mapui:py-1 mapui:text-xs mapui:outline-none',
+                    'focus:mapui:ring-1 focus:mapui:ring-inset focus:mapui:ring-blue-400',
+                    ruleKind === kind
+                      ? 'mapui:bg-blue-500 mapui:text-white'
+                      : 'mapui:bg-white mapui:text-slate-700 hover:mapui:bg-slate-50',
+                  ].join(' ')}
+                >
+                  {kind === 'values' ? 'Values' : kind === 'pattern' ? 'Pattern' : 'Catch-all'}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Values rule */}
+          {rule.kind === 'values' && (
+            <div className="mapui:flex mapui:flex-col mapui:gap-2">
+              {rule.values.length > 0 && (
+                <div className="mapui:flex mapui:flex-wrap mapui:gap-1">
+                  {rule.values.map((v) => (
+                    <span
+                      key={String(v)}
+                      className="mapui:flex mapui:items-center mapui:gap-1 mapui:rounded mapui:bg-slate-100 mapui:px-2 mapui:py-0.5 mapui:text-xs mapui:text-slate-700"
+                    >
+                      {String(v)}
+                      <button
+                        type="button"
+                        onClick={() => removeValue(v)}
+                        className="mapui:cursor-pointer mapui:border-none mapui:bg-transparent mapui:p-0 mapui:text-slate-400 hover:mapui:text-red-500"
+                        aria-label={`Remove ${v}`}
+                      >
+                        ×
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+              <div className="mapui:flex mapui:gap-2">
+                {availableValues.length > 0 ? (
+                  <select
+                    value=""
+                    onChange={(e) => { if (e.target.value) addValue(e.target.value); }}
+                    className={`${inputCls} mapui:flex-1`}
+                  >
+                    <option value="">Add a value…</option>
+                    {availableValues
+                      .filter((v) => !rule.values.includes(v))
+                      .map((v) => (
+                        <option key={v} value={v}>{v}</option>
+                      ))}
+                  </select>
+                ) : (
+                  <>
+                    <input
+                      type="text"
+                      value={valuesInput}
+                      onChange={(e) => setValuesInput(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addValue(valuesInput); } }}
+                      placeholder="Type a value and press Enter"
+                      className={`${inputCls} mapui:flex-1`}
+                    />
+                    <button type="button" onClick={() => addValue(valuesInput)} className={btnCls}>
+                      Add
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Pattern rule */}
+          {rule.kind === 'pattern' && (
+            <div className="mapui:flex mapui:items-center mapui:gap-2">
+              <select
+                value={rule.operator}
+                onChange={(e) =>
+                  onUpdate({
+                    ...group,
+                    matchRule: { ...rule, operator: e.target.value as typeof rule.operator },
+                  })
+                }
+                className={`${inputCls} mapui:shrink-0`}
+              >
+                {PATTERN_OPERATORS.map((op) => (
+                  <option key={op.value} value={op.value}>{op.label}</option>
+                ))}
+              </select>
+              <input
+                type="text"
+                value={rule.pattern}
+                onChange={(e) =>
+                  onUpdate({ ...group, matchRule: { ...rule, pattern: e.target.value } })
+                }
+                placeholder="Pattern text"
+                className={`${inputCls} mapui:flex-1`}
+              />
+            </div>
+          )}
+
+          {/* Catch-all */}
+          {rule.kind === 'catchAll' && (
+            <p className="mapui:m-0 mapui:text-xs mapui:text-slate-500">
+              This group matches everything not covered by other groups. Place it last.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function CategoryGroupEditor({
+  groups,
+  onGroupsChange,
+  availableValues,
+}: CategoryGroupEditorProps) {
+  const addGroup = () => {
+    const newGroup: CategoryGroup = {
+      id: generateId(),
+      label: `Group ${groups.length + 1}`,
+      color: getColorFromPalette(groups.length),
+      matchRule: { kind: 'values', values: [] },
+    };
+    onGroupsChange([...groups, newGroup]);
+  };
+
+  const addCatchAll = () => {
+    const newGroup: CategoryGroup = {
+      id: generateId(),
+      label: 'Other',
+      color: getColorFromPalette(groups.length),
+      matchRule: { kind: 'catchAll' },
+    };
+    onGroupsChange([...groups, newGroup]);
+  };
+
+  const updateGroup = (index: number, updated: CategoryGroup) => {
+    const next = [...groups];
+    next[index] = updated;
+    onGroupsChange(next);
+  };
+
+  const removeGroup = (index: number) => {
+    onGroupsChange(groups.filter((_, i) => i !== index));
+  };
+
+  const moveGroup = (index: number, direction: -1 | 1) => {
+    const next = [...groups];
+    const target = index + direction;
+    if (target < 0 || target >= next.length) return;
+    [next[index], next[target]] = [next[target], next[index]];
+    onGroupsChange(next);
+  };
+
+  const hasCatchAll = groups.some((g) => g.matchRule.kind === 'catchAll');
+
+  return (
+    <div className="mapui:flex mapui:flex-col mapui:gap-2">
+      {groups.length === 0 && (
+        <p className="mapui:m-0 mapui:text-xs mapui:text-slate-500">
+          No groups yet. Add one below.
+        </p>
+      )}
+
+      {groups.map((group, i) => (
+        <GroupRow
+          key={group.id}
+          group={group}
+          index={i}
+          totalGroups={groups.length}
+          availableValues={availableValues}
+          onUpdate={(updated) => updateGroup(i, updated)}
+          onRemove={() => removeGroup(i)}
+          onMoveUp={() => moveGroup(i, -1)}
+          onMoveDown={() => moveGroup(i, 1)}
+        />
+      ))}
+
+      <div className="mapui:flex mapui:gap-2">
+        <button type="button" onClick={addGroup} className={btnCls}>
+          + Add group
+        </button>
+        {!hasCatchAll && (
+          <button type="button" onClick={addCatchAll} className={btnCls}>
+            + Add catch-all
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/map-ui-lib/src/components/CategoryGroupEditor/index.ts
+++ b/packages/map-ui-lib/src/components/CategoryGroupEditor/index.ts
@@ -1,0 +1,2 @@
+export { CategoryGroupEditor } from './CategoryGroupEditor';
+export type { CategoryGroupEditorProps } from './CategoryGroupEditor';

--- a/packages/map-ui-lib/src/components/SearchPanel/SearchPanel.tsx
+++ b/packages/map-ui-lib/src/components/SearchPanel/SearchPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import type { LayerConfig, SearchFilterValues, SearchFilterValue, SearchField, NumberSearchField, DatetimeSearchField, TextSearchField, SelectSearchField, AvailableProperty } from '../../types';
+import type { LayerConfig, SearchFilterValues, SearchFilterValue, SearchField, NumberSearchField, DatetimeSearchField, TextSearchField, SelectSearchField, CategorySearchField, AvailableProperty } from '../../types';
 import type { PropertyFilter } from '../../utils/propertyFilters';
 import { AutocompleteInput } from './AutocompleteInput';
 import { DateRangeInput } from './DateRangeInput';
@@ -269,6 +269,26 @@ export function SearchPanel({
                         {allOptions.map((opt) => (
                           <option key={opt} value={opt}>
                             {opt}
+                          </option>
+                        ))}
+                      </select>
+                    );
+                  })() : field.type === 'category' ? (() => {
+                    const catField = field as CategorySearchField;
+                    return (
+                      <select
+                        id={fieldId}
+                        value={(value as string) ?? ''}
+                        onChange={(e) => {
+                          const newValue = e.target.value || undefined;
+                          onFilterChange(layer.id, field.property, newValue);
+                        }}
+                        className="mapui:rounded mapui:border mapui:border-slate-300 mapui:px-2 mapui:py-1 mapui:text-sm mapui:outline-none focus:mapui:border-blue-500 focus:mapui:ring-1 focus:mapui:ring-blue-500"
+                      >
+                        <option value="">{field.placeholder ?? 'Select a group…'}</option>
+                        {catField.categoryGroups.map((group) => (
+                          <option key={group.id} value={group.id}>
+                            {group.label}
                           </option>
                         ))}
                       </select>

--- a/packages/map-ui-lib/src/components/StyleEditor/DataDrivenColorEditor.tsx
+++ b/packages/map-ui-lib/src/components/StyleEditor/DataDrivenColorEditor.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import type { AvailableProperty, FetchDistinctValuesFn } from '../../types';
+import type { AvailableProperty, FetchDistinctValuesFn, CategoryGroup } from '../../types';
 import { ColorPicker } from '../admin/ColorPicker';
 import { getColorFromPalette } from '../../utils/colorPalettes';
 import { COLOR_THEMES, COLOR_THEME_IDS, type ColorThemeId } from '../../utils/colorThemes';
+import { CategoryGroupEditor } from '../CategoryGroupEditor/CategoryGroupEditor';
+import { categoryGroupsToMaplibreExpression } from '../../utils/categoryGroups';
 
 export interface DataDrivenColorEditorProps {
   value: unknown[];
@@ -15,7 +17,7 @@ export interface DataDrivenColorEditorProps {
   onThemeChange?: (theme: ColorThemeId) => void;
 }
 
-type ExprMode = 'match' | 'interpolate';
+type ExprMode = 'match' | 'interpolate' | 'groups';
 
 interface MatchPair {
   value: string;
@@ -33,7 +35,9 @@ interface EditableStop {
 }
 
 function detectMode(expr: unknown[]): ExprMode {
-  return expr[0] === 'interpolate' ? 'interpolate' : 'match';
+  if (expr[0] === 'interpolate') return 'interpolate';
+  if (expr[0] === 'case') return 'groups';
+  return 'match';
 }
 
 function parseMatchExpr(expr: unknown[]): { property: string; pairs: MatchPair[]; fallback: string } {
@@ -129,6 +133,11 @@ export function DataDrivenColorEditor({
   const [mode, setMode] = useState<ExprMode>(() => detectMode(value));
   const [autoPopulating, setAutoPopulating] = useState(false);
   const [scanAll, setScanAll] = useState(false);
+
+  // Groups mode state
+  const [groupsProperty, setGroupsProperty] = useState('');
+  const [groups, setGroups] = useState<CategoryGroup[]>([]);
+  const [groupsFallback, setGroupsFallback] = useState('#cccccc');
 
   // Match state
   const parsed = parseMatchExpr(value);
@@ -263,16 +272,43 @@ export function DataDrivenColorEditor({
     propagateIfValid(interpolateProperty, next);
   };
 
+  // --- Groups handlers ---
+  const handleGroupsPropertyChange = (property: string) => {
+    setGroupsProperty(property);
+    if (groups.length > 0 && property) {
+      onChange(categoryGroupsToMaplibreExpression(groups, property, groupsFallback));
+    }
+  };
+
+  const handleGroupsChange = (nextGroups: CategoryGroup[]) => {
+    setGroups(nextGroups);
+    if (groupsProperty) {
+      onChange(categoryGroupsToMaplibreExpression(nextGroups, groupsProperty, groupsFallback));
+    }
+  };
+
+  const handleGroupsFallbackChange = (color: string) => {
+    setGroupsFallback(color);
+    if (groupsProperty) {
+      onChange(categoryGroupsToMaplibreExpression(groups, groupsProperty, color));
+    }
+  };
+
   // --- Mode switch ---
   const handleModeSwitch = (newMode: ExprMode) => {
     setMode(newMode);
     if (newMode === 'match') {
       onChange(buildMatchExpr('', [], '#000000'));
-    } else {
+    } else if (newMode === 'interpolate') {
       setEditableStops([]);
       setInterpolateProperty('');
       setStopErrors([]);
       onChange(buildInterpolateExpr('', []));
+    } else {
+      setGroups([]);
+      setGroupsProperty('');
+      setGroupsFallback('#cccccc');
+      onChange(['case', '#cccccc']);
     }
   };
 
@@ -297,20 +333,20 @@ export function DataDrivenColorEditor({
       )}
       {/* Mode toggle */}
       <div className="mapui:flex mapui:overflow-hidden mapui:rounded mapui:border mapui:border-slate-300">
-        {(['match', 'interpolate'] as ExprMode[]).map((m) => (
+        {([['match', 'Categorical'], ['groups', 'Groups'], ['interpolate', 'Gradient']] as [ExprMode, string][]).map(([m, label]) => (
           <button
             key={m}
             type="button"
             onClick={() => handleModeSwitch(m)}
             className={[
-              'mapui:flex-1 mapui:cursor-pointer mapui:border-0 mapui:px-3 mapui:py-1 mapui:text-xs mapui:capitalize mapui:outline-none',
+              'mapui:flex-1 mapui:cursor-pointer mapui:border-0 mapui:px-3 mapui:py-1 mapui:text-xs mapui:outline-none',
               'focus:mapui:ring-1 focus:mapui:ring-inset focus:mapui:ring-blue-400',
               mode === m
                 ? 'mapui:bg-blue-500 mapui:text-white'
                 : 'mapui:bg-white mapui:text-slate-700 hover:mapui:bg-slate-50',
             ].join(' ')}
           >
-            {m === 'match' ? 'Categorical' : 'Gradient'}
+            {label}
           </button>
         ))}
       </div>
@@ -388,6 +424,32 @@ export function DataDrivenColorEditor({
                 </label>
               </>
             )}
+          </div>
+        </>
+      )}
+
+      {mode === 'groups' && (
+        <>
+          <select
+            value={groupsProperty}
+            onChange={(e) => handleGroupsPropertyChange(e.target.value)}
+            className={inputClass}
+          >
+            <option value="">Select a property…</option>
+            {stringProperties.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.title ?? p.name}
+              </option>
+            ))}
+          </select>
+          <CategoryGroupEditor
+            groups={groups}
+            onGroupsChange={handleGroupsChange}
+            availableValues={[]}
+          />
+          <div className="mapui:flex mapui:items-center mapui:gap-2">
+            <span className="mapui:text-xs mapui:text-slate-500 mapui:shrink-0">Fallback:</span>
+            <ColorPicker value={groupsFallback} onChange={handleGroupsFallbackChange} label="Fallback color" />
           </div>
         </>
       )}

--- a/packages/map-ui-lib/src/components/index.ts
+++ b/packages/map-ui-lib/src/components/index.ts
@@ -71,6 +71,8 @@ export type {
   ResultsDrawerSort,
   SortDirection,
 } from './ResultsDrawer';
+export { CategoryGroupEditor } from './CategoryGroupEditor';
+export type { CategoryGroupEditorProps } from './CategoryGroupEditor';
 // Admin components
 export { FormField, ColorPicker, ConfirmDialog, CollapsibleSection } from './admin';
 export type { FormFieldProps, ColorPickerProps, ConfirmDialogProps, CollapsibleSectionProps } from './admin';

--- a/packages/map-ui-lib/src/schemas/config.ts
+++ b/packages/map-ui-lib/src/schemas/config.ts
@@ -288,11 +288,40 @@ export const SelectSearchFieldSchema = z.object({
   zoomTo: z.boolean().optional(),
 });
 
+// --- Category Group Schemas ---
+
+export const CategoryMatchRuleSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('values'),
+    values: z.array(z.union([z.string(), z.number()])),
+  }),
+  z.object({
+    kind: z.literal('pattern'),
+    operator: z.enum(['contains', 'not_contains', 'startsWith', 'endsWith', 'equals', 'not_equals']),
+    pattern: z.string(),
+  }),
+  z.object({ kind: z.literal('catchAll') }),
+]);
+
+export const CategoryGroupSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  color: z.string(),
+  matchRule: CategoryMatchRuleSchema,
+});
+
+export const CategorySearchFieldSchema = z.object({
+  ...searchFieldBase,
+  type: z.literal('category'),
+  categoryGroups: z.array(CategoryGroupSchema).min(1),
+});
+
 export const SearchFieldSchema = z.discriminatedUnion('type', [
   TextSearchFieldSchema,
   NumberSearchFieldSchema,
   DatetimeSearchFieldSchema,
   SelectSearchFieldSchema,
+  CategorySearchFieldSchema,
 ]);
 
 export const SearchConfigSchema = z.object({
@@ -498,6 +527,8 @@ const layerConfigFields = {
   cql2Filter: Cql2FilterConfigSchema.optional(),
   showTooltip: z.boolean().optional(),
   showDetailPanel: z.boolean().optional(),
+  /** Named category groups used for paint expressions and filter shortcuts. */
+  categoryGroups: z.array(CategoryGroupSchema).optional(),
 };
 
 export const LayerConfigSchema = z.preprocess(

--- a/packages/map-ui-lib/src/types/index.ts
+++ b/packages/map-ui-lib/src/types/index.ts
@@ -23,6 +23,9 @@ import {
   NumberSearchFieldSchema,
   DatetimeSearchFieldSchema,
   SelectSearchFieldSchema,
+  CategoryMatchRuleSchema,
+  CategoryGroupSchema,
+  CategorySearchFieldSchema,
   SearchFieldSchema,
   SearchConfigSchema,
   GlobalSearchPropertySchema,
@@ -89,6 +92,9 @@ export type TextSearchField = z.infer<typeof TextSearchFieldSchema>;
 export type NumberSearchField = z.infer<typeof NumberSearchFieldSchema>;
 export type DatetimeSearchField = z.infer<typeof DatetimeSearchFieldSchema>;
 export type SelectSearchField = z.infer<typeof SelectSearchFieldSchema>;
+export type CategoryMatchRule = z.infer<typeof CategoryMatchRuleSchema>;
+export type CategoryGroup = z.infer<typeof CategoryGroupSchema>;
+export type CategorySearchField = z.infer<typeof CategorySearchFieldSchema>;
 export type SearchField = z.infer<typeof SearchFieldSchema>;
 export type SearchConfig = z.infer<typeof SearchConfigSchema>;
 
@@ -204,6 +210,9 @@ export {
   NumberSearchFieldSchema,
   DatetimeSearchFieldSchema,
   SelectSearchFieldSchema,
+  CategoryMatchRuleSchema,
+  CategoryGroupSchema,
+  CategorySearchFieldSchema,
   SearchFieldSchema,
   SearchConfigSchema,
   GlobalSearchPropertySchema,

--- a/packages/map-ui-lib/src/utils/__tests__/categoryGroups.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/categoryGroups.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import { categoryGroupToCql2, categoryGroupsToMaplibreExpression, categoryMatchRuleToCql2 } from '../categoryGroups';
+import type { CategoryGroup } from '../../types';
+
+// ---------------------------------------------------------------------------
+// categoryMatchRuleToCql2
+// ---------------------------------------------------------------------------
+
+describe('categoryMatchRuleToCql2', () => {
+  it('catchAll returns null', () => {
+    expect(categoryMatchRuleToCql2({ kind: 'catchAll' }, 'state')).toBeNull();
+  });
+
+  it('values with empty array returns null', () => {
+    expect(categoryMatchRuleToCql2({ kind: 'values', values: [] }, 'state')).toBeNull();
+  });
+
+  it('values with single item returns equality', () => {
+    expect(categoryMatchRuleToCql2({ kind: 'values', values: ['CO'] }, 'state')).toEqual({
+      op: '=',
+      args: [{ property: 'state' }, 'CO'],
+    });
+  });
+
+  it('values with multiple items returns in', () => {
+    expect(categoryMatchRuleToCql2({ kind: 'values', values: ['CO', 'UT', 'WY'] }, 'state')).toEqual({
+      op: 'in',
+      args: [{ property: 'state' }, ['CO', 'UT', 'WY']],
+    });
+  });
+
+  it('pattern contains returns like with surrounding wildcards', () => {
+    expect(categoryMatchRuleToCql2({ kind: 'pattern', operator: 'contains', pattern: 'LLC' }, 'owner')).toEqual({
+      op: 'like',
+      args: [{ property: 'owner' }, '%LLC%'],
+    });
+  });
+
+  it('pattern not_contains wraps like with not', () => {
+    expect(categoryMatchRuleToCql2({ kind: 'pattern', operator: 'not_contains', pattern: 'LLC' }, 'owner')).toEqual({
+      op: 'not',
+      args: [{ op: 'like', args: [{ property: 'owner' }, '%LLC%'] }],
+    });
+  });
+
+  it('pattern startsWith returns trailing wildcard like', () => {
+    expect(categoryMatchRuleToCql2({ kind: 'pattern', operator: 'startsWith', pattern: 'TRUST' }, 'owner')).toEqual({
+      op: 'like',
+      args: [{ property: 'owner' }, 'TRUST%'],
+    });
+  });
+
+  it('pattern endsWith returns leading wildcard like', () => {
+    expect(categoryMatchRuleToCql2({ kind: 'pattern', operator: 'endsWith', pattern: 'LLC' }, 'owner')).toEqual({
+      op: 'like',
+      args: [{ property: 'owner' }, '%LLC'],
+    });
+  });
+
+  it('pattern equals returns =', () => {
+    expect(categoryMatchRuleToCql2({ kind: 'pattern', operator: 'equals', pattern: 'CO' }, 'state')).toEqual({
+      op: '=',
+      args: [{ property: 'state' }, 'CO'],
+    });
+  });
+
+  it('pattern not_equals returns <>', () => {
+    expect(categoryMatchRuleToCql2({ kind: 'pattern', operator: 'not_equals', pattern: 'CO' }, 'state')).toEqual({
+      op: '<>',
+      args: [{ property: 'state' }, 'CO'],
+    });
+  });
+
+  it('values with numeric array', () => {
+    expect(categoryMatchRuleToCql2({ kind: 'values', values: [1, 2, 3] }, 'zone')).toEqual({
+      op: 'in',
+      args: [{ property: 'zone' }, [1, 2, 3]],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// categoryGroupToCql2
+// ---------------------------------------------------------------------------
+
+describe('categoryGroupToCql2', () => {
+  const makeGroup = (matchRule: CategoryGroup['matchRule']): CategoryGroup => ({
+    id: 'g1',
+    label: 'Test',
+    color: '#ff0000',
+    matchRule,
+  });
+
+  it('delegates to matchRule', () => {
+    const group = makeGroup({ kind: 'values', values: ['CO'] });
+    expect(categoryGroupToCql2(group, 'state')).toEqual({
+      op: '=',
+      args: [{ property: 'state' }, 'CO'],
+    });
+  });
+
+  it('returns null for catchAll group', () => {
+    const group = makeGroup({ kind: 'catchAll' });
+    expect(categoryGroupToCql2(group, 'state')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// categoryGroupsToMaplibreExpression
+// ---------------------------------------------------------------------------
+
+describe('categoryGroupsToMaplibreExpression', () => {
+  it('builds case expression from values groups', () => {
+    const groups: CategoryGroup[] = [
+      { id: '1', label: 'In-state', color: '#blue', matchRule: { kind: 'values', values: ['CO'] } },
+      { id: '2', label: 'Out-of-state', color: '#red', matchRule: { kind: 'catchAll' } },
+    ];
+    expect(categoryGroupsToMaplibreExpression(groups, 'state', '#gray')).toEqual([
+      'case',
+      ['==', ['get', 'state'], 'CO'],
+      '#blue',
+      '#red',
+    ]);
+  });
+
+  it('uses fallbackColor when no catchAll group', () => {
+    const groups: CategoryGroup[] = [
+      { id: '1', label: 'LLC', color: '#red', matchRule: { kind: 'pattern', operator: 'contains', pattern: 'LLC' } },
+    ];
+    const result = categoryGroupsToMaplibreExpression(groups, 'owner', '#gray');
+    expect(result).toEqual([
+      'case',
+      ['in', 'LLC', ['get', 'owner']],
+      '#red',
+      '#gray',
+    ]);
+  });
+
+  it('builds multi-value condition for values with more than one entry', () => {
+    const groups: CategoryGroup[] = [
+      {
+        id: '1',
+        label: 'Region A',
+        color: '#blue',
+        matchRule: { kind: 'values', values: ['AK', 'WA', 'OR'] },
+      },
+    ];
+    const result = categoryGroupsToMaplibreExpression(groups, 'state', '#gray');
+    expect(result).toEqual([
+      'case',
+      ['in', ['get', 'state'], ['literal', ['AK', 'WA', 'OR']]],
+      '#blue',
+      '#gray',
+    ]);
+  });
+
+  it('skips groups with empty values array', () => {
+    const groups: CategoryGroup[] = [
+      { id: '1', label: 'Empty', color: '#red', matchRule: { kind: 'values', values: [] } },
+    ];
+    const result = categoryGroupsToMaplibreExpression(groups, 'state', '#gray');
+    expect(result).toEqual(['case', '#gray']);
+  });
+
+  it('contains pattern uses ["in", pattern, ["get", prop]]', () => {
+    const groups: CategoryGroup[] = [
+      { id: '1', label: 'LLC', color: '#red', matchRule: { kind: 'pattern', operator: 'contains', pattern: 'LLC' } },
+    ];
+    expect(categoryGroupsToMaplibreExpression(groups, 'owner', '#gray')).toEqual([
+      'case',
+      ['in', 'LLC', ['get', 'owner']],
+      '#red',
+      '#gray',
+    ]);
+  });
+
+  it('not_contains wraps in !', () => {
+    const groups: CategoryGroup[] = [
+      { id: '1', label: 'No LLC', color: '#green', matchRule: { kind: 'pattern', operator: 'not_contains', pattern: 'LLC' } },
+    ];
+    expect(categoryGroupsToMaplibreExpression(groups, 'owner', '#gray')).toEqual([
+      'case',
+      ['!', ['in', 'LLC', ['get', 'owner']]],
+      '#green',
+      '#gray',
+    ]);
+  });
+
+  it('startsWith uses slice with pattern.length', () => {
+    const groups: CategoryGroup[] = [
+      { id: '1', label: 'Trust', color: '#purple', matchRule: { kind: 'pattern', operator: 'startsWith', pattern: 'TRUST' } },
+    ];
+    expect(categoryGroupsToMaplibreExpression(groups, 'owner', '#gray')).toEqual([
+      'case',
+      ['==', ['slice', ['get', 'owner'], 0, 5], 'TRUST'],
+      '#purple',
+      '#gray',
+    ]);
+  });
+
+  it('endsWith uses slice with length minus pattern length', () => {
+    const groups: CategoryGroup[] = [
+      { id: '1', label: 'LLC suffix', color: '#red', matchRule: { kind: 'pattern', operator: 'endsWith', pattern: 'LLC' } },
+    ];
+    expect(categoryGroupsToMaplibreExpression(groups, 'owner', '#gray')).toEqual([
+      'case',
+      ['==', ['slice', ['get', 'owner'], ['-', ['length', ['get', 'owner']], 3]], 'LLC'],
+      '#red',
+      '#gray',
+    ]);
+  });
+
+  it('equals uses ==', () => {
+    const groups: CategoryGroup[] = [
+      { id: '1', label: 'Colorado', color: '#blue', matchRule: { kind: 'pattern', operator: 'equals', pattern: 'CO' } },
+    ];
+    expect(categoryGroupsToMaplibreExpression(groups, 'state', '#gray')).toEqual([
+      'case',
+      ['==', ['get', 'state'], 'CO'],
+      '#blue',
+      '#gray',
+    ]);
+  });
+
+  it('not_equals uses !=', () => {
+    const groups: CategoryGroup[] = [
+      { id: '1', label: 'Not CO', color: '#orange', matchRule: { kind: 'pattern', operator: 'not_equals', pattern: 'CO' } },
+    ];
+    expect(categoryGroupsToMaplibreExpression(groups, 'state', '#gray')).toEqual([
+      'case',
+      ['!=', ['get', 'state'], 'CO'],
+      '#orange',
+      '#gray',
+    ]);
+  });
+
+  it('multiple groups produce multiple case branches', () => {
+    const groups: CategoryGroup[] = [
+      { id: '1', label: 'LLC', color: '#red', matchRule: { kind: 'pattern', operator: 'contains', pattern: 'LLC' } },
+      { id: '2', label: 'Trust', color: '#purple', matchRule: { kind: 'pattern', operator: 'contains', pattern: 'TRUST' } },
+      { id: '3', label: 'Other', color: '#gray', matchRule: { kind: 'catchAll' } },
+    ];
+    expect(categoryGroupsToMaplibreExpression(groups, 'owner', '#black')).toEqual([
+      'case',
+      ['in', 'LLC', ['get', 'owner']],
+      '#red',
+      ['in', 'TRUST', ['get', 'owner']],
+      '#purple',
+      '#gray',
+    ]);
+  });
+
+  it('empty groups array returns ["case", fallbackColor]', () => {
+    expect(categoryGroupsToMaplibreExpression([], 'state', '#gray')).toEqual(['case', '#gray']);
+  });
+});

--- a/packages/map-ui-lib/src/utils/categoryGroups.ts
+++ b/packages/map-ui-lib/src/utils/categoryGroups.ts
@@ -1,0 +1,104 @@
+import type { CQL2Expression } from './cql2';
+import { like, inList, not, eq, neq } from './cql2';
+import type { CategoryGroup, CategoryMatchRule } from '../types';
+
+/**
+ * Compiles a single CategoryMatchRule to a CQL2 expression for a given property.
+ * Returns null for `catchAll` rules (they are the else-branch, not a positive condition).
+ */
+export function categoryMatchRuleToCql2(
+  rule: CategoryMatchRule,
+  property: string,
+): CQL2Expression | null {
+  if (rule.kind === 'catchAll') return null;
+
+  if (rule.kind === 'values') {
+    if (rule.values.length === 0) return null;
+    if (rule.values.length === 1) return eq(property, rule.values[0] as string | number);
+    return inList(property, rule.values as (string | number)[]);
+  }
+
+  // pattern
+  const { operator, pattern } = rule;
+  switch (operator) {
+    case 'contains':     return like(property, `%${pattern}%`);
+    case 'not_contains': return not(like(property, `%${pattern}%`));
+    case 'startsWith':   return like(property, `${pattern}%`);
+    case 'endsWith':     return like(property, `%${pattern}`);
+    case 'equals':       return eq(property, pattern);
+    case 'not_equals':   return neq(property, pattern);
+    default:             return null;
+  }
+}
+
+/**
+ * Compiles a CategoryGroup to a CQL2 expression.
+ * Returns null for catchAll groups.
+ */
+export function categoryGroupToCql2(
+  group: CategoryGroup,
+  property: string,
+): CQL2Expression | null {
+  return categoryMatchRuleToCql2(group.matchRule, property);
+}
+
+/**
+ * Builds a MapLibre `case` expression that maps category groups to colors.
+ *
+ * The last group with kind `catchAll` becomes the fallback color. When no
+ * catchAll group is present, `fallbackColor` is used.
+ *
+ * Returned value has the shape:
+ *   ["case", condition1, color1, condition2, color2, ..., fallbackColor]
+ */
+export function categoryGroupsToMaplibreExpression(
+  groups: CategoryGroup[],
+  property: string,
+  fallbackColor: string,
+): unknown[] {
+  const cases: unknown[] = ['case'];
+  let catchAllColor: string | undefined;
+
+  for (const group of groups) {
+    const { kind } = group.matchRule;
+    if (kind === 'catchAll') {
+      catchAllColor = group.color;
+      continue;
+    }
+    const condition = buildMaplibreCondition(group.matchRule, property);
+    if (condition) {
+      cases.push(condition, group.color);
+    }
+  }
+
+  cases.push(catchAllColor ?? fallbackColor);
+  return cases;
+}
+
+function buildMaplibreCondition(rule: CategoryMatchRule, property: string): unknown[] | null {
+  if (rule.kind === 'catchAll') return null;
+
+  if (rule.kind === 'values') {
+    if (rule.values.length === 0) return null;
+    if (rule.values.length === 1) return ['==', ['get', property], rule.values[0]];
+    return ['in', ['get', property], ['literal', rule.values]];
+  }
+
+  const { operator, pattern } = rule;
+  switch (operator) {
+    case 'contains':
+      return ['in', pattern, ['get', property]];
+    case 'not_contains':
+      return ['!', ['in', pattern, ['get', property]]];
+    case 'startsWith':
+      return ['==', ['slice', ['get', property], 0, pattern.length], pattern];
+    case 'endsWith':
+      return ['==', ['slice', ['get', property], ['-', ['length', ['get', property]], pattern.length]], pattern];
+    case 'equals':
+      return ['==', ['get', property], pattern];
+    case 'not_equals':
+      return ['!=', ['get', property], pattern];
+    default:
+      return null;
+  }
+}

--- a/packages/map-ui-lib/src/utils/cql2.ts
+++ b/packages/map-ui-lib/src/utils/cql2.ts
@@ -235,6 +235,14 @@ export function fromStructuredFilters(
 
     const field = fieldMap.get(property);
 
+    // Category field: value is a group id; compile to CQL2 via the group's match rule
+    if (field?.type === 'category' && typeof value === 'string') {
+      const catField = field as import('../types').CategorySearchField;
+      const group = catField.categoryGroups.find((g) => g.id === value);
+      if (!group) return null;
+      return categoryGroupToCql2Inline(group, property);
+    }
+
     // Plain string
     if (typeof value === 'string') {
       if (value === '') return null;
@@ -288,6 +296,34 @@ export function fromStructuredFilters(
 /** Serializes a CQL2 expression to a JSON string for use as a query parameter. */
 export function serializeCql2(expr: CQL2Expression): string {
   return JSON.stringify(expr);
+}
+
+// ---------------------------------------------------------------------------
+// Category group → CQL2 (inline, avoids circular import with categoryGroups.ts)
+// ---------------------------------------------------------------------------
+
+function categoryGroupToCql2Inline(
+  group: import('../types').CategoryGroup,
+  property: string,
+): CQL2Expression | null {
+  const rule = group.matchRule;
+  if (rule.kind === 'catchAll') return null;
+  if (rule.kind === 'values') {
+    if (rule.values.length === 0) return null;
+    if (rule.values.length === 1) return eq(property, rule.values[0] as string | number);
+    return inList(property, rule.values as (string | number)[]);
+  }
+  // pattern
+  const { operator, pattern } = rule;
+  switch (operator) {
+    case 'contains':     return like(property, `%${pattern}%`);
+    case 'not_contains': return not(like(property, `%${pattern}%`));
+    case 'startsWith':   return like(property, `${pattern}%`);
+    case 'endsWith':     return like(property, `%${pattern}`);
+    case 'equals':       return eq(property, pattern);
+    case 'not_equals':   return neq(property, pattern);
+    default:             return null;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/map-ui-lib/src/utils/index.ts
+++ b/packages/map-ui-lib/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './ogcApi';
 export * from './csvExport';
 export * from './cql2';
+export * from './categoryGroups';
 export * from './propertyFilters';
 export * from './propertyDisplay';
 export * from './queryableHelpers';


### PR DESCRIPTION
## Summary
- Adds a **Groups** tab to the categorical color editor in `DataDrivenColorEditor`
- Wires the existing `CategoryGroupEditor` component (built in Phase 3) into the style editor UI
- Users can now define rule-based groups (pattern matching, value lists, catch-all) instead of manually selecting thousands of individual values
- Compiled output is a MapLibre `case` expression via `categoryGroupsToMaplibreExpression`

## What was missing (Phase 4)
The `CategoryGroupEditor` component existed but was never integrated into the admin app paint editor. This PR completes that integration.

## Test plan
- [ ] Open admin app at http://localhost/admin
- [ ] Create or edit a map config with a layer that has string properties (e.g. owner_name)
- [ ] Open the style editor for a fill/line layer → click the `fx` button on Color
- [ ] Confirm three tabs appear: **Categorical | Groups | Gradient**
- [ ] Switch to Groups → select a property → add a pattern group (e.g. "contains LLC") → verify color updates on map
- [ ] Add a catch-all group and confirm it becomes the fallback color
- [ ] Verify Categorical and Gradient tabs still work as before

## Notes
- Groups state is local to the editor session; the compiled `case` expression is what gets saved to the layer config
- Do not merge until reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)