### PR TITLE
fix(ci): bust gateway apk cache for libxml2 CVE-2026-6732

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -12,6 +12,7 @@ jobs:
       packages: write
       security-events: write
     strategy:
+      fail-fast: false
       matrix:
         include:
           - image: map-admin

--- a/docker/gateway/Dockerfile
+++ b/docker/gateway/Dockerfile
@@ -1,4 +1,10 @@
 FROM nginx:alpine
-RUN apk update && apk upgrade --no-cache
+# Bump APK_REVISION (YYYY-MM-DD) to force a fresh apk index past the buildx layer
+# cache when a base-image package CVE needs the upgrade applied.
+ARG APK_REVISION=2026-06-02
+RUN echo "apk revision: $APK_REVISION" \
+  && apk update \
+  && apk upgrade --no-cache \
+  && rm -rf /var/cache/apk/*
 COPY docker/gateway/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
## Why

After PR #101 merged, \`publish-containers\` re-ran on main and still failed — but the real failure was confined to **\`map-gateway\`**. \`map-admin\` and \`map-client\` aborted with \`The operation was canceled\` because the matrix is fail-fast by default.

\`map-gateway\` failed Trivy on **CVE-2026-6732** in \`libxml2@2.13.9-r0\` from \`nginx:alpine\` (HIGH, fixed in \`2.13.9-r1\`). The gateway Dockerfile already had \`apk update && apk upgrade --no-cache\`, but the GHA buildx cache (\`cache-from: type=gha,scope=map-gateway\`) was reusing the pre-r1 layer hash, so the upgrade never re-ran.

## What changed

1. **\`docker/gateway/Dockerfile\`** — added a date-stamped \`APK_REVISION\` ARG referenced in the RUN. Editing the Dockerfile content invalidates the layer hash so the apk upgrade re-runs against the current Alpine index. Also added \`rm -rf /var/cache/apk/*\` for a smaller layer. Future libxml2-style stalls: bump the date.
2. **\`.github/workflows/publish-containers.yml\`** — \`strategy.fail-fast: false\`. One image's CVE shouldn't cancel the other two — \`map-admin\` and \`map-client\` could have published fresh \`:latest\` on the prior run if it hadn't been killed mid-build.

## Test plan
- [ ] Squash-merge.
- [ ] Watch \`publish-containers\` on main: all three jobs should run to completion; gateway's Trivy should report no HIGH/CRITICAL.
- [ ] All three \`:latest\` images push to GHCR.
- [ ] Re-run \`ansible/deploy.sh\` — StyleCard / preset UX visible in deployed admin.