### PR TITLE
fix(ci): bust map-client apk cache for libxml2 CVE-2026-6732

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -12,6 +12,7 @@ jobs:
       packages: write
       security-events: write
     strategy:
+      fail-fast: false
       matrix:
         include:
           - image: map-admin

--- a/apps/map-client/Dockerfile
+++ b/apps/map-client/Dockerfile
@@ -22,7 +22,13 @@ RUN pnpm --filter map-client build
 
 # Stage 2: Runtime
 FROM nginx:alpine AS runtime
-RUN apk update && apk upgrade --no-cache
+# Bump APK_REVISION (YYYY-MM-DD) to force a fresh apk index past the buildx layer
+# cache when a base-image package CVE needs the upgrade applied.
+ARG APK_REVISION=2026-06-02
+RUN echo "apk revision: $APK_REVISION" \
+  && apk update \
+  && apk upgrade --no-cache \
+  && rm -rf /var/cache/apk/*
 
 # Copy SPA fallback nginx config
 COPY apps/map-client/nginx.conf /etc/nginx/conf.d/default.conf

--- a/docker/gateway/Dockerfile
+++ b/docker/gateway/Dockerfile
@@ -1,4 +1,10 @@
 FROM nginx:alpine
-RUN apk update && apk upgrade --no-cache
+# Bump APK_REVISION (YYYY-MM-DD) to force a fresh apk index past the buildx layer
+# cache when a base-image package CVE needs the upgrade applied.
+ARG APK_REVISION=2026-06-02
+RUN echo "apk revision: $APK_REVISION" \
+  && apk update \
+  && apk upgrade --no-cache \
+  && rm -rf /var/cache/apk/*
 COPY docker/gateway/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
Same fix as #102, applied to \`apps/map-client/Dockerfile\`. With \`fail-fast: false\` now in place (merged via #102), this was the last image with the libxml2 cache-hit issue.

After this lands:
- All three publish-containers jobs should complete green.
- Fresh \`map-admin\`, \`map-client\`, \`map-gateway\` :latest images on GHCR.
- \`ansible/deploy.sh\` should pull the new code.