### PR TITLE
fix: guard turfBuffer throw in sDwithin; verify color clipboard eviction

### DIFF
--- a/packages/map-ui-lib/src/hooks/__tests__/useColorClipboard.test.ts
+++ b/packages/map-ui-lib/src/hooks/__tests__/useColorClipboard.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   pushRecentColor,
   _resetColorClipboardForTests,
+  _getRecentColorsForTests,
 } from '../useColorClipboard';
 
 describe('pushRecentColor', () => {
@@ -9,27 +10,25 @@ describe('pushRecentColor', () => {
     _resetColorClipboardForTests();
   });
 
-  it('dedupes and reorders most-recent first', async () => {
-    // Re-import to read fresh recents state via the hook module's
-    // exported reset (state itself is module-private; we observe it via
-    // the next push's effect on what survives the 8-item cap).
+  it('dedupes and reorders most-recent first', () => {
     pushRecentColor('#ff0000');
     pushRecentColor('#00ff00');
     pushRecentColor('#0000ff');
     pushRecentColor('#ff0000'); // dedupe -> moves to front
+    expect(_getRecentColorsForTests()[0]).toBe('#ff0000');
+    expect(_getRecentColorsForTests()).toHaveLength(3);
 
-    // Use dynamic import to inspect via the hook side-effect — but
-    // since recents are module-private, we assert behaviour via the
-    // 8-cap: push 10 unique colors, the earliest two should be evicted.
+    // Push 10 unique colors to exercise the 8-item cap.
+    // Expected final list (MRU order, capped at 8):
+    //   [#000009, #000008, #000007, #000006, #000005, #000004, #000003, #000002]
     for (let i = 0; i < 10; i++) {
       pushRecentColor(`#${i.toString(16).padStart(6, '0')}`);
     }
-    // No throw means the cap logic ran; an explicit assertion via
-    // the hook would require React. The eviction is asserted implicitly:
-    // pushing 14 calls with 11 unique values should not crash and the
-    // store remains finite. This test guards against regressions in
-    // the normalize / hex-validation branches.
-    expect(true).toBe(true);
+
+    const recents = _getRecentColorsForTests();
+    expect(recents).toHaveLength(8);
+    expect(recents[0]).toBe('#000009'); // most recent
+    expect(recents[7]).toBe('#000002'); // oldest surviving (#000000 and #000001 evicted)
   });
 
   it('rejects non-hex strings silently', () => {

--- a/packages/map-ui-lib/src/hooks/useColorClipboard.ts
+++ b/packages/map-ui-lib/src/hooks/useColorClipboard.ts
@@ -83,6 +83,11 @@ export function _resetColorClipboardForTests(): void {
   notify();
 }
 
+/** Test helper: read the current recents list without going through the hook. */
+export function _getRecentColorsForTests(): readonly string[] {
+  return recents;
+}
+
 export interface UseColorClipboardResult {
   /** The most recently copied color, or null if nothing has been copied. */
   clipboard: string | null;

--- a/packages/map-ui-lib/src/utils/cql2.ts
+++ b/packages/map-ui-lib/src/utils/cql2.ts
@@ -196,12 +196,17 @@ export function sDwithin(property: string, geometry: CQL2Geometry, distance: num
       properties: {},
       geometry: geometry as GeoJSON.Geometry,
     };
-    const buffered = turfBuffer(feature, value, { units: turfUnits });
+    let buffered: ReturnType<typeof turfBuffer> | undefined;
+    try {
+      buffered = turfBuffer(feature, value, { units: turfUnits });
+    } catch {
+      /* invalid geometry — fall through to plain sIntersects */
+    }
     if (buffered) {
       return sIntersects(property, buffered.geometry as CQL2Geometry);
     }
   }
-  // Fallback: distance=0 or buffer failed — use plain s_intersects
+  // Fallback: distance=0, null return, or buffer exception — use plain s_intersects
   return sIntersects(property, geometry);
 }
 


### PR DESCRIPTION
## Summary

Two targeted quality fixes found during codebase review (2026-06-25):

- **`cql2.ts` — `sDwithin` turfBuffer exception guard** (closes #166): The `if (buffered)` check handled null/undefined returns from `turfBuffer` but not thrown exceptions on malformed geometry. Added a `try/catch` so invalid geometry silently falls back to plain `sIntersects`, matching the existing comment and the pattern used by every other error-tolerant helper in the file.

- **`useColorClipboard` — real test assertions** (closes #165): The `'dedupes and reorders most-recent first'` test ended with `expect(true).toBe(true)`, which always passes and verifies nothing. Added `_getRecentColorsForTests()` as a test-only state getter and replaced the trivial assertion with concrete checks: cap length (8), MRU ordering (most-recent first), and eviction boundary (oldest two items drop off).

## Test plan

- [x] `pnpm exec vitest run …/useColorClipboard.test.ts` — 3 tests pass, assertions are now meaningful
- [x] `pnpm exec vitest run …/cql2.test.ts` — 93 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011MBECK2MixvCh2QS7L9qs8)_