### PR TITLE
quality: add app test jobs to CI; tighten geojsonGeometryToWkt type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm test
+      # App suites run separately — they can't share `pnpm test` (lib-only)
+      - name: admin-app tests
+        run: cd apps/admin-app && pnpm exec vitest run
+      - name: map-client tests
+        run: cd apps/map-client && pnpm exec vitest run
+      - name: ingest-service unit tests
+        run: pnpm --filter ingest-service test

--- a/packages/map-ui-lib/src/utils/wkt.ts
+++ b/packages/map-ui-lib/src/utils/wkt.ts
@@ -9,19 +9,23 @@ function ringToWkt(ring: Ring): string {
   return ring.map(coordToWkt).join(', ');
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function geojsonGeometryToWkt(geometry: any): string {
-  if (!geometry || !geometry.type) return '';
+/**
+ * Converts a GeoJSON geometry object to its WKT representation.
+ * Accepts the loose `Record<string, unknown>` shape used by OGC API responses
+ * so callers don't need an intermediate cast.
+ */
+export function geojsonGeometryToWkt(geometry: Record<string, unknown> | null | undefined): string {
+  if (!geometry?.type) return '';
 
   switch (geometry.type) {
     case 'Point':
-      return `POINT (${coordToWkt(geometry.coordinates)})`;
+      return `POINT (${coordToWkt(geometry.coordinates as Coord)})`;
 
     case 'MultiPoint':
       return `MULTIPOINT (${(geometry.coordinates as Coord[]).map((c) => `(${coordToWkt(c)})`).join(', ')})`;
 
     case 'LineString':
-      return `LINESTRING (${ringToWkt(geometry.coordinates)})`;
+      return `LINESTRING (${ringToWkt(geometry.coordinates as Ring)})`;
 
     case 'MultiLineString':
       return `MULTILINESTRING (${(geometry.coordinates as Ring[]).map((r) => `(${ringToWkt(r)})`).join(', ')})`;
@@ -33,7 +37,7 @@ export function geojsonGeometryToWkt(geometry: any): string {
       return `MULTIPOLYGON (${(geometry.coordinates as Ring[][]).map((poly) => `(${poly.map((r) => `(${ringToWkt(r)})`).join(', ')})`).join(', ')})`;
 
     case 'GeometryCollection':
-      return `GEOMETRYCOLLECTION (${(geometry.geometries as unknown[]).map(geojsonGeometryToWkt).join(', ')})`;
+      return `GEOMETRYCOLLECTION (${((geometry.geometries as Record<string, unknown>[]) ?? []).map(geojsonGeometryToWkt).join(', ')})`;
 
     default:
       return '';


### PR DESCRIPTION
## Summary

Two focused quality improvements identified during a codebase audit:

- **CI gap** (`closes #136`): The `ci.yml` `test` job only ran `pnpm test` (lib-only). App test suites for `admin-app`, `map-client`, and `ingest-service` were never executed in CI, meaning regressions in those apps would go undetected. Three new steps add them after the lib run.

- **Type safety** (`closes #143`): `geojsonGeometryToWkt` was typed `geometry: any` with a suppressing `eslint-disable-next-line` comment. Changed to `Record<string, unknown> | null | undefined` — strict enough to reject primitives and bare arrays, compatible with the `GeoJsonFeature.geometry: Record<string, unknown>` type used by OGC API responses, and preserving the existing null/undefined guard. All 637 lib tests continue to pass.

## Changes

### `.github/workflows/ci.yml`
Added three steps to the existing `test` job:
```yaml
- name: admin-app tests
  run: cd apps/admin-app && pnpm exec vitest run
- name: map-client tests
  run: cd apps/map-client && pnpm exec vitest run
- name: ingest-service unit tests
  run: pnpm --filter ingest-service test
```

### `packages/map-ui-lib/src/utils/wkt.ts`
- Removed `// eslint-disable-next-line @typescript-eslint/no-explicit-any`
- Changed `geojsonGeometryToWkt(geometry: any)` → `geojsonGeometryToWkt(geometry: Record<string, unknown> | null | undefined)`
- Added a JSDoc comment explaining the `Record<string, unknown>` choice
- Kept the `if (!geometry?.type) return ''` null guard (tests verify null/undefined → `''`)

## Test plan
- [ ] `pnpm test` (lib suite: 637 tests) passes locally — verified ✅
- [ ] CI `test` job runs all four suites (lib + 3 apps) on the PR
- [ ] `wkt.test.ts` (11 tests) still passes — verified ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbEoDdiCpnw7exXikL2DYe)_