### PR TITLE
promote: ai/main → main (16 periodic-review PRs integrated)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,12 @@ jobs:
       - uses: pnpm/action-setup@v4
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - run: pnpm test
+      # Run lib tests with coverage so vitest enforces the threshold values in vitest.config.ts
+      - run: pnpm test:coverage
+        working-directory: packages/map-ui-lib
       # App + sidecar suites aren't part of `pnpm test` (lib only) — run them here.
       - name: admin-app tests
-        run: cd apps/admin-app && pnpm exec vitest run
+        run: cd apps/admin-app && pnpm exec vitest run --coverage
       - name: ingest-service unit tests
         run: pnpm --filter ingest-service test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       - run: pnpm build
       - run: pnpm test
       # App + sidecar suites aren't part of `pnpm test` (lib only) — run them here.
+      - name: map-client tests
+        run: cd apps/map-client && pnpm exec vitest run
       - name: admin-app tests
         run: cd apps/admin-app && pnpm exec vitest run
       - name: ingest-service unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm test
+      # App suites run separately — they can't share `pnpm test` (lib-only)
+      - name: admin-app tests
+        run: cd apps/admin-app && pnpm exec vitest run
+      - name: map-client tests
+        run: cd apps/map-client && pnpm exec vitest run
+      - name: ingest-service unit tests
+        run: pnpm --filter ingest-service test

--- a/apps/admin-app/server/index.ts
+++ b/apps/admin-app/server/index.ts
@@ -1434,7 +1434,7 @@ app.get('/api/basemaps/:id/tiles/:z/:x/:y', async (req, res) => {
     res.setHeader('Cache-Control', 'public, max-age=300');
 
     if (upstream.body) {
-      // @ts-expect-error Node 18+ ReadableStream is compatible with Readable.fromWeb
+      // @ts-expect-error DOM ReadableStream<Uint8Array>.pipeThrough signature diverges from Node's ReadableStream type — runtime-compatible
       const stream = Readable.fromWeb(upstream.body);
       stream.on('error', (err: Error) => {
         console.error('Basemap tile proxy stream error:', err);
@@ -1667,7 +1667,7 @@ app.all('/api/proxy/:sourceId/*', async (req, res) => {
     }
 
     if (upstream.body) {
-      // @ts-expect-error Node 18+ ReadableStream is compatible with Readable.fromWeb
+      // @ts-expect-error DOM ReadableStream<Uint8Array>.pipeThrough signature diverges from Node's ReadableStream type — runtime-compatible
       const stream = Readable.fromWeb(upstream.body);
       stream.on('error', (err: Error) => {
         console.error('Proxy stream error:', err);

--- a/apps/admin-app/src/utils/__tests__/lintMapConfig.test.ts
+++ b/apps/admin-app/src/utils/__tests__/lintMapConfig.test.ts
@@ -195,7 +195,7 @@ describe('lintMapConfig', () => {
       debounceMs: 250,
       minQueryLength: 2,
       layers: [{ layerId: 'empty-layer', properties: [] }],
-    } as GlobalSearchConfig;
+    } as unknown as GlobalSearchConfig;
     expect(lintMapConfig({ ...empty, globalSearch })).toHaveLength(0);
   });
 
@@ -212,7 +212,7 @@ describe('lintMapConfig', () => {
           { property: 'name' }, // duplicate AND no label
         ],
       }],
-    } as GlobalSearchConfig;
+    } as unknown as GlobalSearchConfig;
     const issues = lintMapConfig({ ...empty, globalSearch });
     // 1 duplicate warning + 1 missing-label warning
     expect(issues).toHaveLength(2);

--- a/apps/admin-app/src/utils/__tests__/lintMapConfig.test.ts
+++ b/apps/admin-app/src/utils/__tests__/lintMapConfig.test.ts
@@ -22,10 +22,11 @@ describe('isSearchFieldTypeCompatible', () => {
     return { type, property, label: '' };
   };
 
-  it('text fields accept string + unknown but not number/boolean', () => {
+  it('text fields accept string + unknown but not number/integer/boolean', () => {
     expect(isSearchFieldTypeCompatible(f('text'), ap('string'))).toBe(true);
     expect(isSearchFieldTypeCompatible(f('text'), ap(''))).toBe(true);
     expect(isSearchFieldTypeCompatible(f('text'), ap('number'))).toBe(false);
+    expect(isSearchFieldTypeCompatible(f('text'), ap('integer'))).toBe(false);
     expect(isSearchFieldTypeCompatible(f('text'), ap('boolean'))).toBe(false);
   });
 
@@ -33,6 +34,15 @@ describe('isSearchFieldTypeCompatible', () => {
     expect(isSearchFieldTypeCompatible(f('number'), ap('number'))).toBe(true);
     expect(isSearchFieldTypeCompatible(f('number'), ap('integer'))).toBe(true);
     expect(isSearchFieldTypeCompatible(f('number'), ap('string'))).toBe(false);
+    expect(isSearchFieldTypeCompatible(f('number'), ap('boolean'))).toBe(false);
+  });
+
+  it('select fields accept any scalar type except boolean', () => {
+    expect(isSearchFieldTypeCompatible(f('select'), ap('string'))).toBe(true);
+    expect(isSearchFieldTypeCompatible(f('select'), ap('number'))).toBe(true);
+    expect(isSearchFieldTypeCompatible(f('select'), ap('integer'))).toBe(true);
+    expect(isSearchFieldTypeCompatible(f('select'), ap(''))).toBe(true);
+    expect(isSearchFieldTypeCompatible(f('select'), ap('boolean'))).toBe(false);
   });
 
   it('datetime fields accept date/date-time format strings', () => {
@@ -124,6 +134,69 @@ describe('lintMapConfig', () => {
       queryablesLoading: { roads: true },
     });
     expect(issues).toHaveLength(0);
+  });
+
+  it('does not flag an imagery row with a sourceId + collection', () => {
+    const issues = lintMapConfig({
+      ...empty,
+      imageryLayers: [{ ...baseImagery, sourceId: 's1', collection: 'ortho' }],
+    });
+    expect(issues).toHaveLength(0);
+  });
+
+  it('reports errors only for incomplete imagery rows when mixed with complete ones', () => {
+    const issues = lintMapConfig({
+      ...empty,
+      imageryLayers: [
+        { ...baseImagery, id: 'ok', tileUrlTemplate: 'https://example.com/{z}/{x}/{y}.png' },
+        { ...baseImagery, id: 'bad1' }, // incomplete
+        { ...baseImagery, id: 'ok2', sourceId: 's1', collection: 'c1' },
+        { ...baseImagery, id: 'bad2' }, // incomplete
+      ],
+    });
+    expect(issues).toHaveLength(2);
+    expect(issues[0].remediation).toEqual({ kind: 'remove-imagery-row', index: 1 });
+    expect(issues[1].remediation).toEqual({ kind: 'remove-imagery-row', index: 3 });
+  });
+
+  it('skips search-field validation for a layer whose queryables are absent (not loading)', () => {
+    // queryablesLoading not set, queryablesByLayer has no entry → silent skip
+    const layer: LayerConfig = {
+      id: 'roads',
+      label: 'Roads',
+      sourceId: 's1',
+      collection: 'roads',
+      styles: [],
+      search: { fields: [{ type: 'text', property: 'phantom_field', label: 'X', autocomplete: false }] },
+    } as unknown as LayerConfig;
+    const issues = lintMapConfig({
+      ...empty,
+      layers: [layer],
+      queryablesByLayer: {}, // no entry for 'roads'
+    });
+    expect(issues).toHaveLength(0);
+  });
+
+  it('returns no issues for a layer with no search config', () => {
+    const layer: LayerConfig = {
+      id: 'roads',
+      label: 'Roads',
+      sourceId: 's1',
+      collection: 'roads',
+      styles: [],
+    } as unknown as LayerConfig;
+    expect(lintMapConfig({ ...empty, layers: [layer] })).toHaveLength(0);
+  });
+
+  it('handles a global-search entry with an empty properties array', () => {
+    const globalSearch: GlobalSearchConfig = {
+      enabled: true,
+      maxResultsPerLayer: 5,
+      debounceMs: 250,
+      minQueryLength: 2,
+      layers: [{ layerId: 'empty-layer', properties: [] }],
+    } as GlobalSearchConfig;
+    expect(lintMapConfig({ ...empty, globalSearch })).toHaveLength(0);
   });
 
   it('warns on duplicate global-search properties + missing labels', () => {

--- a/apps/ingest-service/src/ingest.integration.test.ts
+++ b/apps/ingest-service/src/ingest.integration.test.ts
@@ -43,7 +43,12 @@ describe.runIf(RUN)('ingest integration (real ogr2ogr + PostGIS)', () => {
     ogr('-f', 'FlatGeobuf', path.join(dir, 'data.fgb'), geojson);
     ogr('-f', 'KML', path.join(dir, 'data.kml'), geojson);
     ogr('-f', 'CSV', path.join(dir, 'data.csv'), geojson, '-lco', 'GEOMETRY=AS_WKT');
-    ogr('-f', 'ESRI Shapefile', `/vsizip/${path.join(dir, 'shp.zip')}/places.shp`, geojson);
+    // Write the shapefile to a plain dir, then zip it — newer GDAL rejects
+    // random-access writes into /vsizip.
+    const shpDir = path.join(dir, 'shp');
+    fs.mkdirSync(shpDir);
+    ogr('-f', 'ESRI Shapefile', path.join(shpDir, 'places.shp'), geojson);
+    execFileSync('zip', ['-j', path.join(dir, 'shp.zip'), ...fs.readdirSync(shpDir).map((f) => path.join(shpDir, f))], { stdio: 'pipe' });
     // Multi-layer GeoPackage.
     ogr('-f', 'GPKG', path.join(dir, 'multi.gpkg'), geojson, '-nln', 'roads');
     ogr('-f', 'GPKG', '-update', path.join(dir, 'multi.gpkg'), geojson, '-nln', 'rivers');

--- a/apps/ingest-service/vitest.config.ts
+++ b/apps/ingest-service/vitest.config.ts
@@ -8,6 +8,15 @@ export default defineConfig({
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/index.ts'],
+      thresholds: {
+        // Baselined against unit-test-reachable files (contract, formats, identifiers,
+        // ogr, semaphore, unzip). db.ts and ingest.ts are only covered by the
+        // integration suite (INGEST_INTEGRATION=1). Tighten as unit tests are added.
+        statements: 55,
+        branches: 45,
+        functions: 55,
+        lines: 55,
+      },
     },
   },
 });

--- a/apps/map-client/src/hooks/useMapSync.ts
+++ b/apps/map-client/src/hooks/useMapSync.ts
@@ -4,6 +4,38 @@ import type { SearchFilterValue, SearchFilterValues } from '@ogc-maps/storybook-
 import { useMapStore } from '../stores/mapStore';
 import { useMapUrlState } from './useMapUrlState';
 
+// Two-level structural equality for activeFilters.
+// JSON.stringify is order-sensitive: two semantically identical filter objects with
+// different key insertion order (e.g. after a URL round-trip) would compare unequal.
+// SearchFilterValue leaf types are either primitives or shallow objects ({start,end} etc.),
+// so a two-level structural comparison is both correct and cheap.
+function filterValueEqual(a: SearchFilterValue, b: SearchFilterValue): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (typeof a !== 'object' || typeof b !== 'object') return false;
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj);
+  return aKeys.length === Object.keys(bObj).length &&
+    aKeys.every(k => aObj[k] === bObj[k]);
+}
+
+function activeFiltersEqual(
+  a: Record<string, SearchFilterValues>,
+  b: Record<string, SearchFilterValues>,
+): boolean {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) return false;
+  return aKeys.every(layerId => {
+    if (!(layerId in b)) return false;
+    const aFields = a[layerId];
+    const bFields = b[layerId];
+    const fieldKeys = Object.keys(aFields);
+    if (fieldKeys.length !== Object.keys(bFields).length) return false;
+    return fieldKeys.every(k => filterValueEqual(aFields[k], bFields[k]));
+  });
+}
+
 /**
  * Bidirectional sync between Zustand stores and URL parameters.
  *
@@ -154,12 +186,7 @@ export function useMapSync() {
   useEffect(() => {
     if (isSyncingFromUrl.current) return;
 
-    // We only want to push to history if filters actually changed
-    // Simple deep equality check or JSON stringify comp could work for light usage
-    const filtersJson = JSON.stringify(activeFilters);
-    const prevFiltersJson = JSON.stringify(prevFiltersRef.current);
-
-    if (filtersJson !== prevFiltersJson) {
+    if (!activeFiltersEqual(activeFilters, prevFiltersRef.current)) {
       // Filter out empty objects
       const cleanedFilters: Record<string, Record<string, NonNullable<SearchFilterValue>>> = {};
       for (const [layerId, filters] of Object.entries(activeFilters)) {

--- a/apps/map-client/src/stores/__tests__/uiStore.test.ts
+++ b/apps/map-client/src/stores/__tests__/uiStore.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useUIStore } from '../uiStore';
+
+const initialState = useUIStore.getState();
+
+beforeEach(() => {
+  useUIStore.setState({ ...initialState }, true);
+});
+
+describe('uiStore — initial state', () => {
+  it('defaults to sidebar open', () => {
+    expect(useUIStore.getState().sidebarOpen).toBe(true);
+  });
+
+  it('defaults to no active panel', () => {
+    expect(useUIStore.getState().activePanel).toBeNull();
+  });
+
+  it('defaults to not loading', () => {
+    expect(useUIStore.getState().isLoading).toBe(false);
+  });
+});
+
+describe('uiStore — toggleSidebar', () => {
+  it('closes an open sidebar', () => {
+    useUIStore.getState().toggleSidebar();
+    expect(useUIStore.getState().sidebarOpen).toBe(false);
+  });
+
+  it('re-opens after a second toggle', () => {
+    useUIStore.getState().toggleSidebar();
+    useUIStore.getState().toggleSidebar();
+    expect(useUIStore.getState().sidebarOpen).toBe(true);
+  });
+
+  it('toggles from a closed state', () => {
+    useUIStore.setState({ sidebarOpen: false });
+    useUIStore.getState().toggleSidebar();
+    expect(useUIStore.getState().sidebarOpen).toBe(true);
+  });
+});
+
+describe('uiStore — setActivePanel', () => {
+  it('sets the layers panel', () => {
+    useUIStore.getState().setActivePanel('layers');
+    expect(useUIStore.getState().activePanel).toBe('layers');
+  });
+
+  it('sets the legend panel', () => {
+    useUIStore.getState().setActivePanel('legend');
+    expect(useUIStore.getState().activePanel).toBe('legend');
+  });
+
+  it('sets the basemaps panel', () => {
+    useUIStore.getState().setActivePanel('basemaps');
+    expect(useUIStore.getState().activePanel).toBe('basemaps');
+  });
+
+  it('clears the active panel with null', () => {
+    useUIStore.getState().setActivePanel('layers');
+    useUIStore.getState().setActivePanel(null);
+    expect(useUIStore.getState().activePanel).toBeNull();
+  });
+
+  it('switches between panels', () => {
+    useUIStore.getState().setActivePanel('legend');
+    useUIStore.getState().setActivePanel('basemaps');
+    expect(useUIStore.getState().activePanel).toBe('basemaps');
+  });
+});
+
+describe('uiStore — setLoading', () => {
+  it('sets loading to true', () => {
+    useUIStore.getState().setLoading(true);
+    expect(useUIStore.getState().isLoading).toBe(true);
+  });
+
+  it('sets loading to false', () => {
+    useUIStore.setState({ isLoading: true });
+    useUIStore.getState().setLoading(false);
+    expect(useUIStore.getState().isLoading).toBe(false);
+  });
+
+  it('idempotent: setting false when already false', () => {
+    useUIStore.getState().setLoading(false);
+    expect(useUIStore.getState().isLoading).toBe(false);
+  });
+});
+
+describe('uiStore — independent state slices', () => {
+  it('toggleSidebar does not affect activePanel', () => {
+    useUIStore.getState().setActivePanel('legend');
+    useUIStore.getState().toggleSidebar();
+    expect(useUIStore.getState().activePanel).toBe('legend');
+  });
+
+  it('setLoading does not affect sidebarOpen', () => {
+    useUIStore.getState().setLoading(true);
+    expect(useUIStore.getState().sidebarOpen).toBe(true);
+  });
+});

--- a/packages/map-ui-lib/src/components/LayerEditor/LayerEditor.tsx
+++ b/packages/map-ui-lib/src/components/LayerEditor/LayerEditor.tsx
@@ -86,16 +86,17 @@ export function LayerEditor({ value, onChange, availableSources, availableIcons,
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
 
-  // Resolve baseUrl from the selected source
+  // Resolve baseUrl and auth from the selected source
   const source = availableSources.find((s) => s.id === value.sourceId);
   const baseUrl = source?.url ?? null;
+  const sourceAuth = source?.auth;
   const collection = value.collection || null;
 
   // Fetch collections for the dropdown
-  const { collections, loading: collectionsLoading } = useOgcCollections(baseUrl);
+  const { collections, loading: collectionsLoading } = useOgcCollections(baseUrl, sourceAuth);
 
   // Fetch queryables when a collection is selected
-  const { queryables, loading: queryablesLoading } = useOgcQueryables(baseUrl, collection);
+  const { queryables, loading: queryablesLoading } = useOgcQueryables(baseUrl, collection, sourceAuth);
 
   // Derive available non-geometry properties
   const availableProperties: AvailableProperty[] = queryables

--- a/packages/map-ui-lib/src/hooks/__tests__/useColorClipboard.test.ts
+++ b/packages/map-ui-lib/src/hooks/__tests__/useColorClipboard.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   pushRecentColor,
   _resetColorClipboardForTests,
+  _getRecentColorsForTests,
 } from '../useColorClipboard';
 
 describe('pushRecentColor', () => {
@@ -9,27 +10,25 @@ describe('pushRecentColor', () => {
     _resetColorClipboardForTests();
   });
 
-  it('dedupes and reorders most-recent first', async () => {
-    // Re-import to read fresh recents state via the hook module's
-    // exported reset (state itself is module-private; we observe it via
-    // the next push's effect on what survives the 8-item cap).
+  it('dedupes and reorders most-recent first', () => {
     pushRecentColor('#ff0000');
     pushRecentColor('#00ff00');
     pushRecentColor('#0000ff');
     pushRecentColor('#ff0000'); // dedupe -> moves to front
+    expect(_getRecentColorsForTests()[0]).toBe('#ff0000');
+    expect(_getRecentColorsForTests()).toHaveLength(3);
 
-    // Use dynamic import to inspect via the hook side-effect — but
-    // since recents are module-private, we assert behaviour via the
-    // 8-cap: push 10 unique colors, the earliest two should be evicted.
+    // Push 10 unique colors to exercise the 8-item cap.
+    // Expected final list (MRU order, capped at 8):
+    //   [#000009, #000008, #000007, #000006, #000005, #000004, #000003, #000002]
     for (let i = 0; i < 10; i++) {
       pushRecentColor(`#${i.toString(16).padStart(6, '0')}`);
     }
-    // No throw means the cap logic ran; an explicit assertion via
-    // the hook would require React. The eviction is asserted implicitly:
-    // pushing 14 calls with 11 unique values should not crash and the
-    // store remains finite. This test guards against regressions in
-    // the normalize / hex-validation branches.
-    expect(true).toBe(true);
+
+    const recents = _getRecentColorsForTests();
+    expect(recents).toHaveLength(8);
+    expect(recents[0]).toBe('#000009'); // most recent
+    expect(recents[7]).toBe('#000002'); // oldest surviving (#000000 and #000001 evicted)
   });
 
   it('rejects non-hex strings silently', () => {

--- a/packages/map-ui-lib/src/hooks/useColorClipboard.ts
+++ b/packages/map-ui-lib/src/hooks/useColorClipboard.ts
@@ -83,6 +83,11 @@ export function _resetColorClipboardForTests(): void {
   notify();
 }
 
+/** Test helper: read the current recents list without going through the hook. */
+export function _getRecentColorsForTests(): readonly string[] {
+  return recents;
+}
+
 export interface UseColorClipboardResult {
   /** The most recently copied color, or null if nothing has been copied. */
   clipboard: string | null;

--- a/packages/map-ui-lib/src/hooks/useOgcCollectionDetail.ts
+++ b/packages/map-ui-lib/src/hooks/useOgcCollectionDetail.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { fetchCollectionDetail, type OgcCollection } from '../utils/ogcApi';
+import type { SourceAuth } from '../utils/ogcApi';
 
 export interface UseOgcCollectionDetailResult {
   collection: OgcCollection | null;
@@ -12,14 +13,18 @@ export interface UseOgcCollectionDetailResult {
  *
  * @param baseUrl - The base URL of the OGC API server
  * @param collectionId - The collection identifier
+ * @param auth - Optional authentication config for the source
  */
 export function useOgcCollectionDetail(
   baseUrl: string | null,
   collectionId: string | null,
+  auth?: SourceAuth,
 ): UseOgcCollectionDetailResult {
   const [collection, setCollection] = useState<OgcCollection | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+
+  const authKey = auth ? `${auth.type}:${auth.name}:${auth.value}` : '';
 
   useEffect(() => {
     if (!baseUrl || !collectionId) return;
@@ -28,7 +33,7 @@ export function useOgcCollectionDetail(
     setLoading(true);
     setError(null);
 
-    fetchCollectionDetail(baseUrl, collectionId)
+    fetchCollectionDetail(baseUrl, collectionId, auth)
       .then((data) => {
         if (!cancelled) {
           setCollection(data);
@@ -48,7 +53,8 @@ export function useOgcCollectionDetail(
     return () => {
       cancelled = true;
     };
-  }, [baseUrl, collectionId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [baseUrl, collectionId, authKey]);
 
   return { collection, loading, error };
 }

--- a/packages/map-ui-lib/src/hooks/useOgcCollectionDetail.ts
+++ b/packages/map-ui-lib/src/hooks/useOgcCollectionDetail.ts
@@ -24,11 +24,12 @@ export function useOgcCollectionDetail(
   useEffect(() => {
     if (!baseUrl || !collectionId) return;
 
+    const controller = new AbortController();
     let cancelled = false;
     setLoading(true);
     setError(null);
 
-    fetchCollectionDetail(baseUrl, collectionId)
+    fetchCollectionDetail(baseUrl, collectionId, undefined, controller.signal)
       .then((data) => {
         if (!cancelled) {
           setCollection(data);
@@ -47,6 +48,7 @@ export function useOgcCollectionDetail(
 
     return () => {
       cancelled = true;
+      controller.abort();
     };
   }, [baseUrl, collectionId]);
 

--- a/packages/map-ui-lib/src/hooks/useOgcCollectionDetail.ts
+++ b/packages/map-ui-lib/src/hooks/useOgcCollectionDetail.ts
@@ -24,29 +24,24 @@ export function useOgcCollectionDetail(
   useEffect(() => {
     if (!baseUrl || !collectionId) return;
 
-    let cancelled = false;
+    const controller = new AbortController();
     setLoading(true);
     setError(null);
 
-    fetchCollectionDetail(baseUrl, collectionId)
+    fetchCollectionDetail(baseUrl, collectionId, undefined, controller.signal)
       .then((data) => {
-        if (!cancelled) {
-          setCollection(data);
-        }
+        setCollection(data);
       })
       .catch((err: unknown) => {
-        if (!cancelled) {
-          setError(err instanceof Error ? err : new Error(String(err)));
-        }
+        if ((err as { name?: string }).name === 'AbortError') return;
+        setError(err instanceof Error ? err : new Error(String(err)));
       })
       .finally(() => {
-        if (!cancelled) {
-          setLoading(false);
-        }
+        if (!controller.signal.aborted) setLoading(false);
       });
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [baseUrl, collectionId]);
 

--- a/packages/map-ui-lib/src/hooks/useOgcCollections.ts
+++ b/packages/map-ui-lib/src/hooks/useOgcCollections.ts
@@ -24,11 +24,12 @@ export function useOgcCollections(baseUrl: string | null, auth?: SourceAuth): Us
   useEffect(() => {
     if (!baseUrl) return;
 
+    const controller = new AbortController();
     let cancelled = false;
     setLoading(true);
     setError(null);
 
-    fetchCollections(baseUrl, auth)
+    fetchCollections(baseUrl, auth, controller.signal)
       .then((data) => {
         if (!cancelled) {
           setCollections(data);
@@ -47,6 +48,7 @@ export function useOgcCollections(baseUrl: string | null, auth?: SourceAuth): Us
 
     return () => {
       cancelled = true;
+      controller.abort();
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [baseUrl, authKey]);

--- a/packages/map-ui-lib/src/hooks/useOgcCollections.ts
+++ b/packages/map-ui-lib/src/hooks/useOgcCollections.ts
@@ -24,29 +24,24 @@ export function useOgcCollections(baseUrl: string | null, auth?: SourceAuth): Us
   useEffect(() => {
     if (!baseUrl) return;
 
-    let cancelled = false;
+    const controller = new AbortController();
     setLoading(true);
     setError(null);
 
-    fetchCollections(baseUrl, auth)
+    fetchCollections(baseUrl, auth, controller.signal)
       .then((data) => {
-        if (!cancelled) {
-          setCollections(data);
-        }
+        setCollections(data);
       })
       .catch((err: unknown) => {
-        if (!cancelled) {
-          setError(err instanceof Error ? err : new Error(String(err)));
-        }
+        if ((err as { name?: string }).name === 'AbortError') return;
+        setError(err instanceof Error ? err : new Error(String(err)));
       })
       .finally(() => {
-        if (!cancelled) {
-          setLoading(false);
-        }
+        if (!controller.signal.aborted) setLoading(false);
       });
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [baseUrl, authKey]);

--- a/packages/map-ui-lib/src/hooks/useOgcFeatures.ts
+++ b/packages/map-ui-lib/src/hooks/useOgcFeatures.ts
@@ -40,13 +40,14 @@ export function useOgcFeatures(
   useEffect(() => {
     if (!baseUrl || !collection) return;
 
+    const controller = new AbortController();
     let cancelled = false;
     setLoading(true);
     setError(null);
 
     const opts: FetchFeaturesOptions = JSON.parse(optionsKey);
 
-    fetchFeatures(baseUrl, collection, opts, auth)
+    fetchFeatures(baseUrl, collection, opts, auth, controller.signal)
       .then((data: OgcFeatureCollection) => {
         if (!cancelled) {
           setFeatures(data.features);
@@ -77,6 +78,7 @@ export function useOgcFeatures(
 
     return () => {
       cancelled = true;
+      controller.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [baseUrl, collection, optionsKey, authKey]);

--- a/packages/map-ui-lib/src/hooks/useOgcFeatures.ts
+++ b/packages/map-ui-lib/src/hooks/useOgcFeatures.ts
@@ -44,16 +44,14 @@ export function useOgcFeatures(
     setLoading(true);
     setError(null);
 
-    const opts: FetchFeaturesOptions = JSON.parse(optionsKey);
-
-    fetchFeatures(baseUrl, collection, opts, auth)
+    fetchFeatures(baseUrl, collection, options, auth)
       .then((data: OgcFeatureCollection) => {
         if (!cancelled) {
           setFeatures(data.features);
 
           // Determine if more results are available
-          const limit = opts.limit ?? 10;
-          const offset = opts.offset ?? 0;
+          const limit = options.limit ?? 10;
+          const offset = options.offset ?? 0;
           if (data.numberMatched != null) {
             setHasMore(offset + data.features.length < data.numberMatched);
           } else {

--- a/packages/map-ui-lib/src/hooks/useOgcQueryables.ts
+++ b/packages/map-ui-lib/src/hooks/useOgcQueryables.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { fetchQueryables, type OgcQueryables } from '../utils/ogcApi';
+import type { SourceAuth } from '../utils/ogcApi';
 
 export interface UseOgcQueryablesResult {
   queryables: OgcQueryables | null;
@@ -12,14 +13,18 @@ export interface UseOgcQueryablesResult {
  *
  * @param baseUrl - The base URL of the OGC API server
  * @param collectionId - The collection identifier
+ * @param auth - Optional authentication config for the source
  */
 export function useOgcQueryables(
   baseUrl: string | null,
   collectionId: string | null,
+  auth?: SourceAuth,
 ): UseOgcQueryablesResult {
   const [queryables, setQueryables] = useState<OgcQueryables | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+
+  const authKey = auth ? `${auth.type}:${auth.name}:${auth.value}` : '';
 
   useEffect(() => {
     if (!baseUrl || !collectionId) return;
@@ -28,7 +33,7 @@ export function useOgcQueryables(
     setLoading(true);
     setError(null);
 
-    fetchQueryables(baseUrl, collectionId)
+    fetchQueryables(baseUrl, collectionId, auth)
       .then((data) => {
         if (!cancelled) {
           setQueryables(data);
@@ -48,7 +53,8 @@ export function useOgcQueryables(
     return () => {
       cancelled = true;
     };
-  }, [baseUrl, collectionId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [baseUrl, collectionId, authKey]);
 
   return { queryables, loading, error };
 }

--- a/packages/map-ui-lib/src/hooks/useOgcQueryables.ts
+++ b/packages/map-ui-lib/src/hooks/useOgcQueryables.ts
@@ -24,11 +24,12 @@ export function useOgcQueryables(
   useEffect(() => {
     if (!baseUrl || !collectionId) return;
 
+    const controller = new AbortController();
     let cancelled = false;
     setLoading(true);
     setError(null);
 
-    fetchQueryables(baseUrl, collectionId)
+    fetchQueryables(baseUrl, collectionId, undefined, controller.signal)
       .then((data) => {
         if (!cancelled) {
           setQueryables(data);
@@ -47,6 +48,7 @@ export function useOgcQueryables(
 
     return () => {
       cancelled = true;
+      controller.abort();
     };
   }, [baseUrl, collectionId]);
 

--- a/packages/map-ui-lib/src/hooks/useOgcQueryables.ts
+++ b/packages/map-ui-lib/src/hooks/useOgcQueryables.ts
@@ -24,29 +24,24 @@ export function useOgcQueryables(
   useEffect(() => {
     if (!baseUrl || !collectionId) return;
 
-    let cancelled = false;
+    const controller = new AbortController();
     setLoading(true);
     setError(null);
 
-    fetchQueryables(baseUrl, collectionId)
+    fetchQueryables(baseUrl, collectionId, undefined, controller.signal)
       .then((data) => {
-        if (!cancelled) {
-          setQueryables(data);
-        }
+        setQueryables(data);
       })
       .catch((err: unknown) => {
-        if (!cancelled) {
-          setError(err instanceof Error ? err : new Error(String(err)));
-        }
+        if ((err as { name?: string }).name === 'AbortError') return;
+        setError(err instanceof Error ? err : new Error(String(err)));
       })
       .finally(() => {
-        if (!cancelled) {
-          setLoading(false);
-        }
+        if (!controller.signal.aborted) setLoading(false);
       });
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [baseUrl, collectionId]);
 

--- a/packages/map-ui-lib/src/hooks/useSelection.ts
+++ b/packages/map-ui-lib/src/hooks/useSelection.ts
@@ -1,6 +1,10 @@
 import { useState, useMemo, useCallback } from 'react';
 import type { SelectionMode, SelectedFeature } from '../utils/selection';
-import { selectedFeatureKey } from '../utils/selection';
+import {
+  selectedFeatureKey,
+  mergeUniqueFeatures,
+  buildHighlightFeatureCollection,
+} from '../utils/selection';
 
 export interface UseSelectionResult {
   mode: SelectionMode | null;
@@ -14,24 +18,12 @@ export interface UseSelectionResult {
   clearFeatures: () => void;
 }
 
-const MAX_SELECTED = 1000;
-
 export function useSelection(): UseSelectionResult {
   const [mode, setModeState] = useState<SelectionMode | null>(null);
   const [activeLayerId, setActiveLayerIdState] = useState<string | null>(null);
   const [features, setFeatures] = useState<SelectedFeature[]>([]);
 
-  const highlightData = useMemo<GeoJSON.FeatureCollection | null>(() => {
-    if (features.length === 0) return null;
-    return {
-      type: 'FeatureCollection',
-      features: features.map((f) => ({
-        type: 'Feature' as const,
-        properties: f.properties,
-        geometry: f.geometry as unknown as GeoJSON.Geometry,
-      })),
-    };
-  }, [features]);
+  const highlightData = useMemo(() => buildHighlightFeatureCollection(features), [features]);
 
   const setMode = useCallback((newMode: SelectionMode | null) => {
     setModeState(newMode);
@@ -43,12 +35,7 @@ export function useSelection(): UseSelectionResult {
   }, []);
 
   const addFeatures = useCallback((newFeatures: SelectedFeature[]) => {
-    setFeatures((prev) => {
-      const existingKeys = new Set(prev.map(selectedFeatureKey));
-      const unique = newFeatures.filter((f) => !existingKeys.has(selectedFeatureKey(f)));
-      const combined = [...prev, ...unique];
-      return combined.length > MAX_SELECTED ? combined.slice(0, MAX_SELECTED) : combined;
-    });
+    setFeatures((prev) => mergeUniqueFeatures(prev, newFeatures));
   }, []);
 
   const removeFeature = useCallback((key: string) => {

--- a/packages/map-ui-lib/src/schemas/__tests__/config.test.ts
+++ b/packages/map-ui-lib/src/schemas/__tests__/config.test.ts
@@ -100,6 +100,21 @@ describe('LayerConfigSchema backward-compat preprocess', () => {
     expect(Array.isArray((result.styles![2] as any).layout['icon-image'])).toBe(true);
   });
 
+  it('accepts expression for text-field (data-driven labels)', () => {
+    const input = {
+      ...base,
+      styles: [
+        {
+          type: 'symbol',
+          paint: { 'text-color': '#000' },
+          layout: { 'text-field': ['get', 'name'], 'text-size': 12 },
+        },
+      ],
+    };
+    const result = LayerConfigSchema.parse(input);
+    expect(Array.isArray((result.styles![0] as any).layout['text-field'])).toBe(true);
+  });
+
   it('still accepts plain number/string values for line-width, circle-radius, icon-image (back-compat)', () => {
     const input = {
       ...base,

--- a/packages/map-ui-lib/src/schemas/config.ts
+++ b/packages/map-ui-lib/src/schemas/config.ts
@@ -195,7 +195,7 @@ export const SymbolLayoutSchema = z.object({
   'icon-pitch-alignment': z.enum(['map', 'viewport', 'auto']).optional(),
   'text-pitch-alignment': z.enum(['map', 'viewport', 'auto']).optional(),
   'text-rotation-alignment': z.enum(['map', 'viewport', 'viewport-glyph', 'auto']).optional(),
-  'text-field': z.string().optional(),
+  'text-field': stringOrExprOptional(),
   'text-font': z.array(z.string()).optional(),
   'text-size': z.number().min(0).optional(),
   'text-max-width': z.number().min(0).optional(),

--- a/packages/map-ui-lib/src/utils/__tests__/boxDraw.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/boxDraw.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { buildBoxPolygon, buildBoxDrawData } from '../boxDraw';
+
+describe('buildBoxPolygon', () => {
+  it('returns a closed ring (first coordinate equals last)', () => {
+    const poly = buildBoxPolygon([10, 20], [30, 40]);
+    const ring = poly.coordinates[0];
+    expect(ring[0]).toEqual(ring[ring.length - 1]);
+  });
+
+  it('builds the four expected corners in order', () => {
+    const poly = buildBoxPolygon([10, 20], [30, 40]);
+    expect(poly.type).toBe('Polygon');
+    expect(poly.coordinates[0]).toEqual([
+      [10, 20],
+      [30, 20],
+      [30, 40],
+      [10, 40],
+      [10, 20],
+    ]);
+  });
+
+  it('works when the second corner has smaller lng/lat (reversed corners)', () => {
+    const poly = buildBoxPolygon([30, 40], [10, 20]);
+    expect(poly.type).toBe('Polygon');
+    expect(poly.coordinates[0]).toHaveLength(5);
+    const ring = poly.coordinates[0];
+    expect(ring[0]).toEqual(ring[ring.length - 1]);
+  });
+
+  it('handles zero-area degenerate box (both corners equal)', () => {
+    const poly = buildBoxPolygon([5, 5], [5, 5]);
+    const ring = poly.coordinates[0];
+    expect(ring).toHaveLength(5);
+    // All five points are identical
+    ring.forEach(pt => expect(pt).toEqual([5, 5]));
+  });
+});
+
+describe('buildBoxDrawData', () => {
+  it('returns a GeoJSON Feature wrapping the polygon', () => {
+    const feature = buildBoxDrawData([0, 0], [1, 1]);
+    expect(feature.type).toBe('Feature');
+    expect(feature.geometry.type).toBe('Polygon');
+    expect(feature.properties).toEqual({});
+  });
+
+  it('geometry equals buildBoxPolygon output for the same corners', () => {
+    const feature = buildBoxDrawData([10, 20], [30, 40]);
+    expect(feature.geometry).toEqual(buildBoxPolygon([10, 20], [30, 40]));
+  });
+});

--- a/packages/map-ui-lib/src/utils/__tests__/colorPalettes.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/colorPalettes.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { getColorFromPalette } from '../colorPalettes';
+import { getColorFromTheme } from '../colorThemes';
+
+describe('getColorFromPalette', () => {
+  it('returns the same color as getColorFromTheme with no theme', () => {
+    for (let i = 0; i < 5; i++) {
+      expect(getColorFromPalette(i)).toBe(getColorFromTheme(i));
+    }
+  });
+
+  it('returns the same color as getColorFromTheme for a named theme', () => {
+    expect(getColorFromPalette(2, 'warm')).toBe(getColorFromTheme(2, 'warm'));
+  });
+
+  it('wraps correctly when index exceeds palette length', () => {
+    expect(getColorFromPalette(100, 'monochrome')).toBe(getColorFromTheme(100, 'monochrome'));
+  });
+});

--- a/packages/map-ui-lib/src/utils/__tests__/colorThemes.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/colorThemes.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  COLOR_THEMES,
+  COLOR_THEME_IDS,
+  getThemePalette,
+  getColorFromTheme,
+} from '../colorThemes';
+
+describe('COLOR_THEMES', () => {
+  it('has an entry for every id listed in COLOR_THEME_IDS', () => {
+    for (const id of COLOR_THEME_IDS) {
+      expect(COLOR_THEMES[id], `missing theme: ${id}`).toBeDefined();
+    }
+  });
+
+  it('every theme has a non-empty palette of hex strings', () => {
+    for (const id of COLOR_THEME_IDS) {
+      const { palette } = COLOR_THEMES[id];
+      expect(palette.length, `${id} palette is empty`).toBeGreaterThan(0);
+      for (const color of palette) {
+        expect(color, `${id}: "${color}" not a hex color`).toMatch(/^#[0-9a-f]{6}$/i);
+      }
+    }
+  });
+});
+
+describe('getThemePalette', () => {
+  it('returns the default palette when no theme is supplied', () => {
+    expect(getThemePalette()).toBe(COLOR_THEMES.default.palette);
+  });
+
+  it('returns the correct palette for each named theme', () => {
+    for (const id of COLOR_THEME_IDS) {
+      expect(getThemePalette(id)).toBe(COLOR_THEMES[id].palette);
+    }
+  });
+
+  it('falls back to the default palette for an unrecognised theme id', () => {
+    expect(getThemePalette('unknown' as never)).toBe(COLOR_THEMES.default.palette);
+  });
+});
+
+describe('getColorFromTheme', () => {
+  it('index 0 returns the first color of the default palette', () => {
+    expect(getColorFromTheme(0)).toBe(COLOR_THEMES.default.palette[0]);
+  });
+
+  it('index equal to palette length wraps back to index 0', () => {
+    const len = COLOR_THEMES.default.palette.length;
+    expect(getColorFromTheme(len)).toBe(COLOR_THEMES.default.palette[0]);
+  });
+
+  it('index beyond palette length wraps via modulo', () => {
+    const palette = COLOR_THEMES.earth.palette;
+    expect(getColorFromTheme(palette.length + 3, 'earth')).toBe(palette[3]);
+  });
+
+  it('uses the supplied theme palette', () => {
+    expect(getColorFromTheme(0, 'accessible')).toBe(COLOR_THEMES.accessible.palette[0]);
+    expect(getColorFromTheme(1, 'ocean')).toBe(COLOR_THEMES.ocean.palette[1]);
+  });
+});

--- a/packages/map-ui-lib/src/utils/__tests__/download.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/download.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { downloadBlob } from '../download';
+
+// jsdom does not implement URL.createObjectURL / revokeObjectURL.
+URL.createObjectURL = vi.fn(() => 'blob:http://localhost/mock-url');
+URL.revokeObjectURL = vi.fn();
+
+describe('downloadBlob', () => {
+  beforeEach(() => {
+    vi.mocked(URL.createObjectURL).mockReturnValue('blob:http://localhost/mock-url');
+    vi.mocked(URL.revokeObjectURL).mockClear();
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  });
+
+  it('creates an object URL from the provided blob', () => {
+    const blob = new Blob(['hello'], { type: 'text/plain' });
+    downloadBlob(blob, 'test.txt');
+    expect(URL.createObjectURL).toHaveBeenCalledWith(blob);
+  });
+
+  it('sets href and download attribute on the anchor before clicking', () => {
+    const appendSpy = vi.spyOn(document.body, 'appendChild');
+    const blob = new Blob(['data'], { type: 'text/csv' });
+    downloadBlob(blob, 'export.csv');
+    const anchor = appendSpy.mock.calls[0][0] as HTMLAnchorElement;
+    expect(anchor.href).toBe('blob:http://localhost/mock-url');
+    expect(anchor.download).toBe('export.csv');
+    expect(anchor.style.display).toBe('none');
+  });
+
+  it('clicks the anchor to trigger the download', () => {
+    const blob = new Blob([''], { type: 'application/json' });
+    downloadBlob(blob, 'data.json');
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the anchor from the document after clicking', () => {
+    const appendSpy = vi.spyOn(document.body, 'appendChild');
+    const removeSpy = vi.spyOn(document.body, 'removeChild');
+    const blob = new Blob(['x']);
+    downloadBlob(blob, 'file.bin');
+    expect(removeSpy).toHaveBeenCalledWith(appendSpy.mock.calls[0][0]);
+  });
+
+  it('revokes the object URL after clicking', () => {
+    const blob = new Blob(['x']);
+    downloadBlob(blob, 'file.bin');
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/mock-url');
+  });
+});

--- a/packages/map-ui-lib/src/utils/__tests__/exportFormats.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/exportFormats.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_EXPORT_FORMATS } from '../exportFormats';
+
+describe('DEFAULT_EXPORT_FORMATS', () => {
+  it('contains six formats', () => {
+    expect(DEFAULT_EXPORT_FORMATS).toHaveLength(6);
+  });
+
+  it('every format has required fields', () => {
+    for (const fmt of DEFAULT_EXPORT_FORMATS) {
+      expect(fmt.id, `${fmt.id} missing id`).toBeTruthy();
+      expect(fmt.label, `${fmt.id} missing label`).toBeTruthy();
+      expect(fmt.extension, `${fmt.id} missing extension`).toBeTruthy();
+      expect(fmt.description, `${fmt.id} missing description`).toBeTruthy();
+    }
+  });
+
+  it('all extensions start with a dot', () => {
+    for (const fmt of DEFAULT_EXPORT_FORMATS) {
+      expect(fmt.extension.startsWith('.'), `${fmt.id} extension should start with '.'`).toBe(true);
+    }
+  });
+
+  it('all ids are unique', () => {
+    const ids = DEFAULT_EXPORT_FORMATS.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('includes expected format ids', () => {
+    const ids = DEFAULT_EXPORT_FORMATS.map((f) => f.id);
+    expect(ids).toContain('csv');
+    expect(ids).toContain('geojson');
+    expect(ids).toContain('kml');
+    expect(ids).toContain('shapefile');
+    expect(ids).toContain('flatgeobuf');
+    expect(ids).toContain('geopackage');
+  });
+
+  it('shapefile uses .zip extension (multi-file format)', () => {
+    const shapefile = DEFAULT_EXPORT_FORMATS.find((f) => f.id === 'shapefile');
+    expect(shapefile?.extension).toBe('.zip');
+  });
+});

--- a/packages/map-ui-lib/src/utils/__tests__/geo.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/geo.test.ts
@@ -28,6 +28,60 @@ describe('bboxFromGeometry', () => {
   it('returns null for an empty geometry', () => {
     expect(bboxFromGeometry({ type: 'Polygon', coordinates: [] })).toBeNull();
   });
+
+  it('computes bbox for a MultiPoint', () => {
+    const bbox = bboxFromGeometry({
+      type: 'MultiPoint',
+      coordinates: [[0, 1], [5, 3], [2, 8]],
+    });
+    expect(bbox).toEqual([0, 1, 5, 8]);
+  });
+
+  it('computes bbox for a LineString', () => {
+    const bbox = bboxFromGeometry({
+      type: 'LineString',
+      coordinates: [[-10, 0], [10, 5], [0, -3]],
+    });
+    expect(bbox).toEqual([-10, -3, 10, 5]);
+  });
+
+  it('computes bbox for a MultiLineString', () => {
+    const bbox = bboxFromGeometry({
+      type: 'MultiLineString',
+      coordinates: [[[0, 0], [1, 1]], [[3, 4], [5, 2]]],
+    });
+    expect(bbox).toEqual([0, 0, 5, 4]);
+  });
+
+  it('computes bbox for a MultiPolygon', () => {
+    const bbox = bboxFromGeometry({
+      type: 'MultiPolygon',
+      coordinates: [
+        [[[0, 0], [2, 0], [2, 2], [0, 2], [0, 0]]],
+        [[[5, 5], [8, 5], [8, 9], [5, 9], [5, 5]]],
+      ],
+    });
+    expect(bbox).toEqual([0, 0, 8, 9]);
+  });
+
+  it('computes bbox for a GeometryCollection by combining member geometries', () => {
+    const bbox = bboxFromGeometry({
+      type: 'GeometryCollection',
+      geometries: [
+        { type: 'Point', coordinates: [-5, 2] },
+        { type: 'Point', coordinates: [7, -1] },
+      ],
+    });
+    // GeometryCollection bbox should span both points (no per-point padding)
+    expect(bbox![0]).toBeLessThanOrEqual(-5);
+    expect(bbox![2]).toBeGreaterThanOrEqual(7);
+    expect(bbox![1]).toBeLessThanOrEqual(-1);
+    expect(bbox![3]).toBeGreaterThanOrEqual(2);
+  });
+
+  it('returns null for an unknown geometry type', () => {
+    expect(bboxFromGeometry({ type: 'Unknown', coordinates: [[0, 0]] })).toBeNull();
+  });
 });
 
 describe('combineGeometries', () => {

--- a/packages/map-ui-lib/src/utils/__tests__/id.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/id.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { generateId } from '../id';
+
+describe('generateId', () => {
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+  it('returns a valid UUID v4', () => {
+    expect(generateId()).toMatch(UUID_RE);
+  });
+
+  it('returns unique values across many calls', () => {
+    const ids = Array.from({ length: 100 }, generateId);
+    expect(new Set(ids).size).toBe(100);
+  });
+
+  it('fallback path produces a valid UUID v4 when randomUUID is absent', () => {
+    const original = crypto.randomUUID;
+    // @ts-expect-error intentionally removing native API to test fallback
+    crypto.randomUUID = undefined;
+    try {
+      expect(generateId()).toMatch(UUID_RE);
+    } finally {
+      crypto.randomUUID = original;
+    }
+  });
+
+  it('fallback sets version nibble to 4', () => {
+    const original = crypto.randomUUID;
+    // @ts-expect-error
+    crypto.randomUUID = undefined;
+    try {
+      const id = generateId();
+      expect(id[14]).toBe('4');
+    } finally {
+      crypto.randomUUID = original;
+    }
+  });
+
+  it('fallback sets variant bits correctly (8, 9, a, or b)', () => {
+    const original = crypto.randomUUID;
+    // @ts-expect-error
+    crypto.randomUUID = undefined;
+    try {
+      const id = generateId();
+      expect(['8', '9', 'a', 'b']).toContain(id[19]);
+    } finally {
+      crypto.randomUUID = original;
+    }
+  });
+});

--- a/packages/map-ui-lib/src/utils/__tests__/ogcApi.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/ogcApi.test.ts
@@ -724,3 +724,79 @@ describe('error handling (fetchJson)', () => {
     await expect(fetchCollections(BASE)).rejects.toThrow(BASE);
   });
 });
+
+// ─── AbortSignal threading ───────────────────────────────────────────────────
+
+describe('AbortSignal threading', () => {
+  it('fetchCollections passes signal to fetch', async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ collections: [] }),
+    } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchCollections(BASE, undefined, controller.signal);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
+  it('fetchQueryables passes signal to fetch', async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ type: 'object', properties: {} }),
+    } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchQueryables(BASE, 'roads', undefined, controller.signal);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
+  it('fetchCollectionDetail passes signal to fetch', async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 'roads', links: [] }),
+    } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchCollectionDetail(BASE, 'roads', undefined, controller.signal);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
+  it('fetchFeatures passes signal to fetch', async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ type: 'FeatureCollection', features: [] }),
+    } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchFeatures(BASE, 'roads', {}, undefined, controller.signal);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
+  it('rejects with AbortError when signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(
+      Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }),
+    ));
+
+    await expect(fetchCollections(BASE, undefined, controller.signal)).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+  });
+});

--- a/packages/map-ui-lib/src/utils/__tests__/ogcApi.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/ogcApi.test.ts
@@ -465,6 +465,29 @@ describe('fetchQueryables', () => {
     expect(calledUrl).toContain('/collections/roads/queryables');
     expect(calledUrl).toContain('f=schemajson');
   });
+
+  it('passes header auth', async () => {
+    const queryables = { type: 'object', properties: {} };
+    vi.stubGlobal('fetch', mockFetchResponse(queryables));
+    await fetchQueryables(BASE, 'roads', HEADER_AUTH);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/collections/roads/queryables'),
+      { headers: { Authorization: 'Bearer tok' } },
+    );
+  });
+
+  it('appends query_param auth to URL', async () => {
+    const queryables = { type: 'object', properties: {} };
+    vi.stubGlobal('fetch', mockFetchResponse(queryables));
+    await fetchQueryables(BASE, 'roads', QUERY_AUTH);
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('apikey=abc123');
+  });
+
+  it('throws on non-OK response', async () => {
+    vi.stubGlobal('fetch', mockFetchError(403));
+    await expect(fetchQueryables(BASE, 'roads')).rejects.toThrow('OGC API request failed: 403');
+  });
 });
 
 describe('fetchCollectionDetail', () => {
@@ -476,6 +499,29 @@ describe('fetchCollectionDetail', () => {
     expect(result).toEqual(collection);
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(calledUrl).toContain('/collections/roads?f=json');
+  });
+
+  it('passes header auth', async () => {
+    const collection = { id: 'roads', title: 'Roads', links: [] };
+    vi.stubGlobal('fetch', mockFetchResponse(collection));
+    await fetchCollectionDetail(BASE, 'roads', HEADER_AUTH);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/collections/roads'),
+      { headers: { Authorization: 'Bearer tok' } },
+    );
+  });
+
+  it('appends query_param auth to URL', async () => {
+    const collection = { id: 'roads', title: 'Roads', links: [] };
+    vi.stubGlobal('fetch', mockFetchResponse(collection));
+    await fetchCollectionDetail(BASE, 'roads', QUERY_AUTH);
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('apikey=abc123');
+  });
+
+  it('throws on non-OK response', async () => {
+    vi.stubGlobal('fetch', mockFetchError(404));
+    await expect(fetchCollectionDetail(BASE, 'roads')).rejects.toThrow('OGC API request failed: 404');
   });
 });
 

--- a/packages/map-ui-lib/src/utils/__tests__/ogcApi.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/ogcApi.test.ts
@@ -352,6 +352,14 @@ describe('fetchCollections', () => {
     vi.stubGlobal('fetch', mockFetchError(500));
     await expect(fetchCollections(BASE)).rejects.toThrow('OGC API request failed: 500');
   });
+
+  it('forwards AbortSignal to fetch', async () => {
+    vi.stubGlobal('fetch', mockFetchResponse({ collections: [] }));
+    const controller = new AbortController();
+    await fetchCollections(BASE, undefined, controller.signal);
+    const fetchOpts = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+    expect(fetchOpts.signal).toBe(controller.signal);
+  });
 });
 
 describe('fetchFeatures', () => {
@@ -465,6 +473,14 @@ describe('fetchQueryables', () => {
     expect(calledUrl).toContain('/collections/roads/queryables');
     expect(calledUrl).toContain('f=schemajson');
   });
+
+  it('forwards AbortSignal to fetch', async () => {
+    vi.stubGlobal('fetch', mockFetchResponse({ type: 'object', properties: {} }));
+    const controller = new AbortController();
+    await fetchQueryables(BASE, 'roads', undefined, controller.signal);
+    const fetchOpts = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+    expect(fetchOpts.signal).toBe(controller.signal);
+  });
 });
 
 describe('fetchCollectionDetail', () => {
@@ -477,6 +493,14 @@ describe('fetchCollectionDetail', () => {
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(calledUrl).toContain('/collections/roads?f=json');
   });
+
+  it('forwards AbortSignal to fetch', async () => {
+    vi.stubGlobal('fetch', mockFetchResponse({ id: 'roads', links: [] }));
+    const controller = new AbortController();
+    await fetchCollectionDetail(BASE, 'roads', undefined, controller.signal);
+    const fetchOpts = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+    expect(fetchOpts.signal).toBe(controller.signal);
+  });
 });
 
 describe('fetchConformance', () => {
@@ -488,6 +512,14 @@ describe('fetchConformance', () => {
     expect(result.conformsTo).toHaveLength(1);
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(calledUrl).toContain('/conformance?f=json');
+  });
+
+  it('forwards AbortSignal to fetch', async () => {
+    vi.stubGlobal('fetch', mockFetchResponse({ conformsTo: [] }));
+    const controller = new AbortController();
+    await fetchConformance(BASE, undefined, controller.signal);
+    const fetchOpts = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+    expect(fetchOpts.signal).toBe(controller.signal);
   });
 });
 

--- a/packages/map-ui-lib/src/utils/__tests__/selection.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/selection.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { selectedFeatureKey } from '../selection';
+import type { SelectedFeature } from '../selection';
+
+const base = (overrides: Partial<SelectedFeature> = {}): SelectedFeature => ({
+  id: undefined,
+  layerId: 'layer-a',
+  properties: {},
+  geometry: {},
+  ...overrides,
+});
+
+describe('selectedFeatureKey', () => {
+  it('uses numeric id when present', () => {
+    expect(selectedFeatureKey(base({ id: 42 }))).toBe('layer-a:42');
+  });
+
+  it('uses string id when present', () => {
+    expect(selectedFeatureKey(base({ id: 'abc' }))).toBe('layer-a:abc');
+  });
+
+  it('falls back to JSON properties when id is undefined', () => {
+    expect(selectedFeatureKey(base({ properties: { name: 'Park' } }))).toBe(
+      'layer-a:{"name":"Park"}',
+    );
+  });
+
+  it('falls back to JSON properties when id is null', () => {
+    // SelectedFeature.id is typed as string|number|undefined, but callers
+    // can pass null from untyped sources — ensure != null guard handles it.
+    expect(
+      selectedFeatureKey(base({ id: null as unknown as undefined, properties: { x: 1 } })),
+    ).toBe('layer-a:{"x":1}');
+  });
+
+  it('includes layerId in every key', () => {
+    const keyA = selectedFeatureKey({ ...base({ id: 1 }), layerId: 'roads' });
+    const keyB = selectedFeatureKey({ ...base({ id: 1 }), layerId: 'parcels' });
+    expect(keyA).not.toBe(keyB);
+    expect(keyA).toBe('roads:1');
+    expect(keyB).toBe('parcels:1');
+  });
+
+  it('two features with same layerId+id produce the same key regardless of properties', () => {
+    const a = base({ id: 1, properties: { ignored: true } });
+    const b = base({ id: 1, properties: { different: 'value' } });
+    expect(selectedFeatureKey(a)).toBe(selectedFeatureKey(b));
+  });
+
+  it('two features with no id but different properties produce different keys', () => {
+    const a = base({ properties: { name: 'A' } });
+    const b = base({ properties: { name: 'B' } });
+    expect(selectedFeatureKey(a)).not.toBe(selectedFeatureKey(b));
+  });
+});

--- a/packages/map-ui-lib/src/utils/__tests__/selection.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/selection.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import {
+  selectedFeatureKey,
+  mergeUniqueFeatures,
+  buildHighlightFeatureCollection,
+  MAX_SELECTION,
+  type SelectedFeature,
+} from '../selection';
+
+function makeFeature(
+  id: string | number | undefined,
+  layerId = 'layer1',
+  props: Record<string, unknown> = {},
+): SelectedFeature {
+  return { id, layerId, properties: { name: String(id), ...props }, geometry: { type: 'Point', coordinates: [0, 0] } };
+}
+
+// ---------------------------------------------------------------------------
+// selectedFeatureKey
+// ---------------------------------------------------------------------------
+
+describe('selectedFeatureKey', () => {
+  it('returns layerId:id for a string id', () => {
+    expect(selectedFeatureKey(makeFeature('abc'))).toBe('layer1:abc');
+  });
+
+  it('returns layerId:id for a numeric id', () => {
+    expect(selectedFeatureKey(makeFeature(42))).toBe('layer1:42');
+  });
+
+  it('returns layerId:id when id is 0 (falsy but defined)', () => {
+    expect(selectedFeatureKey(makeFeature(0))).toBe('layer1:0');
+  });
+
+  it('falls back to JSON.stringify(properties) when id is undefined', () => {
+    const f: SelectedFeature = {
+      id: undefined,
+      layerId: 'myLayer',
+      properties: { x: 1, y: 'hello' },
+      geometry: { type: 'Point', coordinates: [0, 0] },
+    };
+    expect(selectedFeatureKey(f)).toBe('myLayer:{"x":1,"y":"hello"}');
+  });
+
+  it('different layerIds produce different keys even with the same feature id', () => {
+    const a = makeFeature('id', 'layerA');
+    const b = makeFeature('id', 'layerB');
+    expect(selectedFeatureKey(a)).not.toBe(selectedFeatureKey(b));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeUniqueFeatures
+// ---------------------------------------------------------------------------
+
+describe('mergeUniqueFeatures', () => {
+  it('appends non-duplicate features', () => {
+    const a = makeFeature('a');
+    const b = makeFeature('b');
+    const result = mergeUniqueFeatures([a], [b]);
+    expect(result).toHaveLength(2);
+    expect(result[1]).toBe(b);
+  });
+
+  it('skips incoming features whose key already exists', () => {
+    const a = makeFeature('a');
+    const result = mergeUniqueFeatures([a], [a]);
+    expect(result).toHaveLength(1);
+  });
+
+  it('skips partial duplicates when only some incoming are new', () => {
+    const a = makeFeature('a');
+    const b = makeFeature('b');
+    const result = mergeUniqueFeatures([a], [a, b]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('preserves existing order and appends unique incoming in order', () => {
+    const a = makeFeature('a');
+    const b = makeFeature('b');
+    const c = makeFeature('c');
+    const result = mergeUniqueFeatures([a, b], [c, a]);
+    expect(result.map((f) => f.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('caps at MAX_SELECTION by default', () => {
+    const existing = Array.from({ length: MAX_SELECTION - 1 }, (_, i) => makeFeature(i));
+    const incoming = [makeFeature('x'), makeFeature('y')];
+    const result = mergeUniqueFeatures(existing, incoming);
+    expect(result).toHaveLength(MAX_SELECTION);
+    expect(result[MAX_SELECTION - 1].id).toBe('x');
+  });
+
+  it('does not exceed MAX_SELECTION even with many new features', () => {
+    const existing = Array.from({ length: MAX_SELECTION }, (_, i) => makeFeature(i));
+    const incoming = Array.from({ length: 100 }, (_, i) => makeFeature(`extra_${i}`));
+    expect(mergeUniqueFeatures(existing, incoming)).toHaveLength(MAX_SELECTION);
+  });
+
+  it('respects a custom max', () => {
+    const a = makeFeature('a');
+    const b = makeFeature('b');
+    const c = makeFeature('c');
+    const result = mergeUniqueFeatures([a, b], [c], 2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('does not mutate the existing array', () => {
+    const existing = [makeFeature('a')];
+    const copy = [...existing];
+    mergeUniqueFeatures(existing, [makeFeature('b')]);
+    expect(existing).toEqual(copy);
+  });
+
+  it('handles an empty existing array', () => {
+    const b = makeFeature('b');
+    expect(mergeUniqueFeatures([], [b])).toEqual([b]);
+  });
+
+  it('handles an empty incoming array', () => {
+    const a = makeFeature('a');
+    expect(mergeUniqueFeatures([a], [])).toEqual([a]);
+  });
+
+  it('deduplicates by property-key fallback when id is undefined', () => {
+    const f1: SelectedFeature = { id: undefined, layerId: 'l', properties: { v: 1 }, geometry: { type: 'Point', coordinates: [0, 0] } };
+    const f2: SelectedFeature = { id: undefined, layerId: 'l', properties: { v: 1 }, geometry: { type: 'Point', coordinates: [1, 1] } };
+    expect(mergeUniqueFeatures([f1], [f2])).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildHighlightFeatureCollection
+// ---------------------------------------------------------------------------
+
+describe('buildHighlightFeatureCollection', () => {
+  it('returns null for an empty array', () => {
+    expect(buildHighlightFeatureCollection([])).toBeNull();
+  });
+
+  it('returns a FeatureCollection for a non-empty array', () => {
+    const fc = buildHighlightFeatureCollection([makeFeature('a')]);
+    expect(fc?.type).toBe('FeatureCollection');
+  });
+
+  it('includes one GeoJSON Feature per selected feature', () => {
+    const fc = buildHighlightFeatureCollection([makeFeature('a'), makeFeature('b')]);
+    expect(fc?.features).toHaveLength(2);
+  });
+
+  it('preserves properties on each feature', () => {
+    const f = makeFeature('a', 'layer1', { score: 42 });
+    const fc = buildHighlightFeatureCollection([f]);
+    expect(fc?.features[0].properties).toMatchObject({ name: 'a', score: 42 });
+  });
+
+  it('sets type: Feature on each entry', () => {
+    const fc = buildHighlightFeatureCollection([makeFeature('a')]);
+    expect(fc?.features[0].type).toBe('Feature');
+  });
+});

--- a/packages/map-ui-lib/src/utils/__tests__/selection.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/selection.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { selectedFeatureKey } from '../selection';
+
+describe('selectedFeatureKey', () => {
+  it('uses layerId + feature id when id is present', () => {
+    const key = selectedFeatureKey({ id: 42, layerId: 'parcels', properties: {}, geometry: {} });
+    expect(key).toBe('parcels:42');
+  });
+
+  it('uses layerId + feature id for string ids', () => {
+    const key = selectedFeatureKey({ id: 'abc', layerId: 'roads', properties: {}, geometry: {} });
+    expect(key).toBe('roads:abc');
+  });
+
+  it('falls back to stable property serialization when id is undefined', () => {
+    const key = selectedFeatureKey({
+      id: undefined,
+      layerId: 'layer1',
+      properties: { name: 'Alice', age: 30 },
+      geometry: {},
+    });
+    expect(key).toBe('layer1:{"age":30,"name":"Alice"}');
+  });
+
+  it('produces the same key regardless of property insertion order', () => {
+    const featureA = {
+      id: undefined,
+      layerId: 'layer1',
+      properties: { name: 'Alice', age: 30 },
+      geometry: {},
+    };
+    const featureB = {
+      id: undefined,
+      layerId: 'layer1',
+      properties: { age: 30, name: 'Alice' },
+      geometry: {},
+    };
+    expect(selectedFeatureKey(featureA)).toBe(selectedFeatureKey(featureB));
+  });
+
+  it('treats id=null as absent (falls back to properties)', () => {
+    const key = selectedFeatureKey({
+      id: undefined,
+      layerId: 'layer1',
+      properties: { z: 1 },
+      geometry: {},
+    });
+    expect(key).toContain('layer1:');
+    expect(key).toContain('"z":1');
+  });
+});

--- a/packages/map-ui-lib/src/utils/__tests__/slugify.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/slugify.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { slugify } from '../slugify';
+
+describe('slugify', () => {
+  it('lowercases text', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+
+  it('replaces spaces with hyphens', () => {
+    expect(slugify('hello world')).toBe('hello-world');
+  });
+
+  it('collapses consecutive non-alphanumeric chars into a single hyphen', () => {
+    expect(slugify('a  b')).toBe('a-b');
+    expect(slugify('a--b')).toBe('a-b');
+    expect(slugify('a!@#b')).toBe('a-b');
+  });
+
+  it('strips leading and trailing hyphens', () => {
+    expect(slugify(' hello ')).toBe('hello');
+    expect(slugify('-hello-')).toBe('hello');
+    expect(slugify('!hello!')).toBe('hello');
+  });
+
+  it('handles empty string', () => {
+    expect(slugify('')).toBe('');
+  });
+
+  it('handles string of only special characters', () => {
+    expect(slugify('!@#$')).toBe('');
+  });
+
+  it('preserves digits', () => {
+    expect(slugify('layer 1')).toBe('layer-1');
+    expect(slugify('v2.0')).toBe('v2-0');
+  });
+
+  it('handles already-valid slug unchanged', () => {
+    expect(slugify('my-layer')).toBe('my-layer');
+  });
+});

--- a/packages/map-ui-lib/src/utils/__tests__/spriteUtils.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/spriteUtils.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  fetchSpriteUrlFromStyle,
+  fetchSpriteNames,
+  resolveStyleWithSprites,
+  resolveAvailableIcons,
+} from '../spriteUtils';
+
+// restoreMocks:true in vitest config restores stubs after each test,
+// so we must re-stub in beforeEach.
+let mockFetch: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockFetch = vi.fn();
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+function okJson(body: unknown) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response);
+}
+function notOk() {
+  return Promise.resolve({ ok: false } as Response);
+}
+
+describe('fetchSpriteUrlFromStyle', () => {
+  it('returns null when fetch fails with non-ok response', async () => {
+    mockFetch.mockReturnValue(notOk());
+    expect(await fetchSpriteUrlFromStyle('http://x')).toBeNull();
+  });
+
+  it('returns null when style has no sprite', async () => {
+    mockFetch.mockReturnValue(okJson({}));
+    expect(await fetchSpriteUrlFromStyle('http://x')).toBeNull();
+  });
+
+  it('returns the sprite string URL', async () => {
+    mockFetch.mockReturnValue(okJson({ sprite: 'http://sprites/base' }));
+    expect(await fetchSpriteUrlFromStyle('http://x')).toBe('http://sprites/base');
+  });
+
+  it('returns first url from sprite array', async () => {
+    const sprite = [
+      { id: 'default', url: 'http://sprites/default' },
+      { id: 'maki', url: 'http://sprites/maki' },
+    ];
+    mockFetch.mockReturnValue(okJson({ sprite }));
+    expect(await fetchSpriteUrlFromStyle('http://x')).toBe('http://sprites/default');
+  });
+
+  it('returns null on network error', async () => {
+    mockFetch.mockImplementation(() => { throw new Error('network'); });
+    expect(await fetchSpriteUrlFromStyle('http://x')).toBeNull();
+  });
+});
+
+describe('fetchSpriteNames', () => {
+  it('returns sorted icon names', async () => {
+    mockFetch.mockReturnValue(okJson({ zoo: {}, airport: {}, bank: {} }));
+    expect(await fetchSpriteNames('http://sprites/base')).toEqual(['airport', 'bank', 'zoo']);
+  });
+
+  it('returns empty array when fetch fails', async () => {
+    mockFetch.mockReturnValue(notOk());
+    expect(await fetchSpriteNames('http://sprites/base')).toEqual([]);
+  });
+
+  it('appends .json to sprite url', async () => {
+    mockFetch.mockReturnValue(okJson({}));
+    await fetchSpriteNames('http://sprites/base');
+    expect(mockFetch).toHaveBeenCalledWith('http://sprites/base.json');
+  });
+});
+
+describe('resolveStyleWithSprites', () => {
+  it('throws when style fetch fails', async () => {
+    mockFetch.mockReturnValue(notOk());
+    await expect(resolveStyleWithSprites('http://style', [])).rejects.toThrow('Failed to fetch style');
+  });
+
+  it('returns style unchanged when no custom sprites', async () => {
+    const style = { version: 8, sprite: 'http://base-sprite' };
+    mockFetch.mockReturnValue(okJson(style));
+    const result = await resolveStyleWithSprites('http://style', []);
+    expect(result).toEqual(style);
+  });
+
+  it('merges custom sprites, promoting existing string sprite to array', async () => {
+    const style = { version: 8, sprite: 'http://base-sprite' };
+    mockFetch.mockReturnValue(okJson(style));
+    const custom = [{ id: 'custom', url: 'http://custom-sprite' }];
+    const result = await resolveStyleWithSprites('http://style', custom);
+    expect(result.sprite).toEqual([
+      { id: 'default', url: 'http://base-sprite' },
+      { id: 'custom', url: 'http://custom-sprite' },
+    ]);
+  });
+
+  it('overrides existing sprite with same id', async () => {
+    const style = { version: 8, sprite: [{ id: 'maki', url: 'http://old' }] };
+    mockFetch.mockReturnValue(okJson(style));
+    const custom = [{ id: 'maki', url: 'http://new' }];
+    const result = await resolveStyleWithSprites('http://style', custom);
+    const sprites = result.sprite as Array<{ id: string; url: string }>;
+    const maki = sprites.filter((s) => s.id === 'maki');
+    expect(maki).toHaveLength(1);
+    expect(maki[0].url).toBe('http://new');
+  });
+});
+
+describe('resolveAvailableIcons', () => {
+  it('returns empty array when no args provided', async () => {
+    expect(await resolveAvailableIcons()).toEqual([]);
+  });
+
+  it('prefixes icons from non-default sprites', async () => {
+    // Use URL-based routing because basemap and custom sprite fetches run concurrently.
+    mockFetch.mockImplementation((url: string) => {
+      if (url === 'http://style') return okJson({ sprite: [{ id: 'maki', url: 'http://maki' }] });
+      if (url === 'http://maki.json') return okJson({ bank: {}, park: {} });
+      return notOk();
+    });
+
+    const icons = await resolveAvailableIcons('http://style');
+    expect(icons).toEqual(['maki:bank', 'maki:park']);
+  });
+
+  it('returns bare names for default sprite', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url === 'http://style') return okJson({ sprite: [{ id: 'default', url: 'http://default' }] });
+      if (url === 'http://default.json') return okJson({ dot: {}, circle: {} });
+      return notOk();
+    });
+
+    const icons = await resolveAvailableIcons('http://style');
+    expect(icons).toEqual(['circle', 'dot']);
+  });
+
+  it('merges basemap and custom sprite icons, deduplicating', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url === 'http://style') return okJson({ sprite: [{ id: 'default', url: 'http://base' }] });
+      if (url === 'http://base.json') return okJson({ dot: {}, circle: {} });
+      if (url === 'http://custom.json') return okJson({ dot: {}, star: {} });
+      return notOk();
+    });
+
+    const icons = await resolveAvailableIcons('http://style', [{ id: 'custom', url: 'http://custom' }]);
+    expect(icons).toContain('dot');
+    expect(icons).toContain('circle');
+    expect(icons).toContain('custom:dot');
+    expect(icons).toContain('custom:star');
+    // deduplication: bare 'dot' and 'custom:dot' are distinct (different namespaces)
+    expect(icons.filter((i) => i === 'dot')).toHaveLength(1);
+  });
+});

--- a/packages/map-ui-lib/src/utils/colorPalettes.ts
+++ b/packages/map-ui-lib/src/utils/colorPalettes.ts
@@ -3,6 +3,10 @@ import { getColorFromTheme, type ColorThemeId } from './colorThemes';
 /**
  * Returns a color from the categorical palette, optionally scoped to a theme.
  * Cycles when index exceeds palette length.
+ *
+ * @deprecated Use `getColorFromTheme` from `./colorThemes` directly — this
+ * wrapper exists only for backwards compatibility and will be removed in a
+ * future major release.
  */
 export function getColorFromPalette(index: number, theme?: ColorThemeId): string {
   return getColorFromTheme(index, theme);

--- a/packages/map-ui-lib/src/utils/colorThemes.ts
+++ b/packages/map-ui-lib/src/utils/colorThemes.ts
@@ -117,6 +117,8 @@ export const COLOR_THEMES: Record<ColorThemeId, ColorTheme> = {
       '#f0f0f0',
     ],
   },
+  // The Wong 2011 palette defines exactly 8 colors by design; getColorFromTheme
+  // cycles via modulo so callers don't need to guard against palette length.
   accessible: {
     id: 'accessible',
     label: 'Accessible',

--- a/packages/map-ui-lib/src/utils/cql2.ts
+++ b/packages/map-ui-lib/src/utils/cql2.ts
@@ -196,12 +196,17 @@ export function sDwithin(property: string, geometry: CQL2Geometry, distance: num
       properties: {},
       geometry: geometry as GeoJSON.Geometry,
     };
-    const buffered = turfBuffer(feature, value, { units: turfUnits });
+    let buffered: ReturnType<typeof turfBuffer> | undefined;
+    try {
+      buffered = turfBuffer(feature, value, { units: turfUnits });
+    } catch {
+      /* invalid geometry — fall through to plain sIntersects */
+    }
     if (buffered) {
       return sIntersects(property, buffered.geometry as CQL2Geometry);
     }
   }
-  // Fallback: distance=0 or buffer failed — use plain s_intersects
+  // Fallback: distance=0, null return, or buffer exception — use plain s_intersects
   return sIntersects(property, geometry);
 }
 

--- a/packages/map-ui-lib/src/utils/id.ts
+++ b/packages/map-ui-lib/src/utils/id.ts
@@ -1,11 +1,14 @@
 export function generateId(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
+  if (typeof crypto !== 'undefined') {
+    if (typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+    // Fallback for non-secure contexts: build UUID v4 via getRandomValues
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 1
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
   }
-  // Fallback: build UUID v4 from crypto.getRandomValues (works in non-secure contexts)
-  const bytes = crypto.getRandomValues(new Uint8Array(16));
-  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
-  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 1
-  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  throw new Error('generateId: crypto is not available in this environment');
 }

--- a/packages/map-ui-lib/src/utils/ogcApi.ts
+++ b/packages/map-ui-lib/src/utils/ogcApi.ts
@@ -98,7 +98,11 @@ export interface FetchFeaturesOptions {
   offset?: number;
   properties?: string[];
   datetime?: string;
-  /** @deprecated Use cql2Filter instead. Simple key-value equality filters. */
+  /**
+   * @deprecated Use `cql2Filter` instead. This field will be removed in the
+   * next major release. Build an equality expression with the `eq` / `and`
+   * helpers from `./cql2` and pass it as `cql2Filter`.
+   */
   filter?: Record<string, string | number>;
   /** CQL2 JSON filter expression. When provided, takes precedence over filter. */
   cql2Filter?: CQL2Expression;

--- a/packages/map-ui-lib/src/utils/ogcApi.ts
+++ b/packages/map-ui-lib/src/utils/ogcApi.ts
@@ -502,8 +502,7 @@ export function getVectorTileSourceKey(layerId: string, cql2Filter?: CQL2Express
  * Build a MapLibre geometry-type filter expression for restricting which
  * geometry types a layer renders.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function buildGeometryFilter(types: string[]): any {
+export function buildGeometryFilter(types: string[]): unknown[] {
   return types.length === 1
     ? ['==', ['geometry-type'], types[0]]
     : ['in', ['geometry-type'], ['literal', types]];

--- a/packages/map-ui-lib/src/utils/ogcApi.ts
+++ b/packages/map-ui-lib/src/utils/ogcApi.ts
@@ -141,9 +141,13 @@ async function fetchJson<T>(url: string, auth?: SourceAuth, signal?: AbortSignal
  * Fetch the list of collections from an OGC API endpoint.
  * @throws {Error} If the request fails or the response status is not OK.
  */
-export async function fetchCollections(baseUrl: string, auth?: SourceAuth): Promise<OgcCollection[]> {
+export async function fetchCollections(
+  baseUrl: string,
+  auth?: SourceAuth,
+  signal?: AbortSignal,
+): Promise<OgcCollection[]> {
   const url = `${stripTrailingSlash(baseUrl)}/collections?f=json`;
-  const data = await fetchJson<OgcCollectionsResponse>(url, auth);
+  const data = await fetchJson<OgcCollectionsResponse>(url, auth, signal);
   return data.collections;
 }
 
@@ -215,10 +219,11 @@ export async function fetchQueryables(
   baseUrl: string,
   collection: string,
   auth?: SourceAuth,
+  signal?: AbortSignal,
 ): Promise<OgcQueryables> {
   const base = stripTrailingSlash(baseUrl);
   const url = `${base}/collections/${encodeURIComponent(collection)}/queryables?f=schemajson`;
-  return fetchJson<OgcQueryables>(url, auth);
+  return fetchJson<OgcQueryables>(url, auth, signal);
 }
 
 /**
@@ -229,19 +234,24 @@ export async function fetchCollectionDetail(
   baseUrl: string,
   collectionId: string,
   auth?: SourceAuth,
+  signal?: AbortSignal,
 ): Promise<OgcCollection> {
   const base = stripTrailingSlash(baseUrl);
   const url = `${base}/collections/${encodeURIComponent(collectionId)}?f=json`;
-  return fetchJson<OgcCollection>(url, auth);
+  return fetchJson<OgcCollection>(url, auth, signal);
 }
 
 /**
  * Fetch the OGC API conformance declaration to discover server capabilities.
  * @throws {Error} If the request fails or the response status is not OK.
  */
-export async function fetchConformance(baseUrl: string, auth?: SourceAuth): Promise<OgcConformance> {
+export async function fetchConformance(
+  baseUrl: string,
+  auth?: SourceAuth,
+  signal?: AbortSignal,
+): Promise<OgcConformance> {
   const url = `${stripTrailingSlash(baseUrl)}/conformance?f=json`;
-  return fetchJson<OgcConformance>(url, auth);
+  return fetchJson<OgcConformance>(url, auth, signal);
 }
 
 /**
@@ -502,8 +512,7 @@ export function getVectorTileSourceKey(layerId: string, cql2Filter?: CQL2Express
  * Build a MapLibre geometry-type filter expression for restricting which
  * geometry types a layer renders.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function buildGeometryFilter(types: string[]): any {
+export function buildGeometryFilter(types: string[]): unknown[] {
   return types.length === 1
     ? ['==', ['geometry-type'], types[0]]
     : ['in', ['geometry-type'], ['literal', types]];

--- a/packages/map-ui-lib/src/utils/ogcApi.ts
+++ b/packages/map-ui-lib/src/utils/ogcApi.ts
@@ -141,9 +141,9 @@ async function fetchJson<T>(url: string, auth?: SourceAuth, signal?: AbortSignal
  * Fetch the list of collections from an OGC API endpoint.
  * @throws {Error} If the request fails or the response status is not OK.
  */
-export async function fetchCollections(baseUrl: string, auth?: SourceAuth): Promise<OgcCollection[]> {
+export async function fetchCollections(baseUrl: string, auth?: SourceAuth, signal?: AbortSignal): Promise<OgcCollection[]> {
   const url = `${stripTrailingSlash(baseUrl)}/collections?f=json`;
-  const data = await fetchJson<OgcCollectionsResponse>(url, auth);
+  const data = await fetchJson<OgcCollectionsResponse>(url, auth, signal);
   return data.collections;
 }
 
@@ -215,10 +215,11 @@ export async function fetchQueryables(
   baseUrl: string,
   collection: string,
   auth?: SourceAuth,
+  signal?: AbortSignal,
 ): Promise<OgcQueryables> {
   const base = stripTrailingSlash(baseUrl);
   const url = `${base}/collections/${encodeURIComponent(collection)}/queryables?f=schemajson`;
-  return fetchJson<OgcQueryables>(url, auth);
+  return fetchJson<OgcQueryables>(url, auth, signal);
 }
 
 /**
@@ -229,10 +230,11 @@ export async function fetchCollectionDetail(
   baseUrl: string,
   collectionId: string,
   auth?: SourceAuth,
+  signal?: AbortSignal,
 ): Promise<OgcCollection> {
   const base = stripTrailingSlash(baseUrl);
   const url = `${base}/collections/${encodeURIComponent(collectionId)}?f=json`;
-  return fetchJson<OgcCollection>(url, auth);
+  return fetchJson<OgcCollection>(url, auth, signal);
 }
 
 /**

--- a/packages/map-ui-lib/src/utils/selection.ts
+++ b/packages/map-ui-lib/src/utils/selection.ts
@@ -12,5 +12,8 @@ export interface SelectedFeature {
 /** Build a unique key for a selected feature for deduplication. */
 export function selectedFeatureKey(feature: SelectedFeature): string {
   if (feature.id != null) return `${feature.layerId}:${feature.id}`;
-  return `${feature.layerId}:${JSON.stringify(feature.properties)}`;
+  // Sort keys so the key is stable regardless of property insertion order.
+  const sorted: Record<string, unknown> = {};
+  for (const k of Object.keys(feature.properties).sort()) sorted[k] = feature.properties[k];
+  return `${feature.layerId}:${JSON.stringify(sorted)}`;
 }

--- a/packages/map-ui-lib/src/utils/selection.ts
+++ b/packages/map-ui-lib/src/utils/selection.ts
@@ -14,3 +14,39 @@ export function selectedFeatureKey(feature: SelectedFeature): string {
   if (feature.id != null) return `${feature.layerId}:${feature.id}`;
   return `${feature.layerId}:${JSON.stringify(feature.properties)}`;
 }
+
+/** Maximum number of features that can be held in a selection. */
+export const MAX_SELECTION = 1000;
+
+/**
+ * Merge `incoming` features into `existing`, skipping duplicates (by key) and capping at `max`.
+ * Returns a new array; does not mutate either input.
+ */
+export function mergeUniqueFeatures(
+  existing: SelectedFeature[],
+  incoming: SelectedFeature[],
+  max = MAX_SELECTION,
+): SelectedFeature[] {
+  const existingKeys = new Set(existing.map(selectedFeatureKey));
+  const unique = incoming.filter((f) => !existingKeys.has(selectedFeatureKey(f)));
+  const combined = [...existing, ...unique];
+  return combined.length > max ? combined.slice(0, max) : combined;
+}
+
+/**
+ * Build a GeoJSON FeatureCollection suitable for highlight rendering.
+ * Returns `null` when the selection is empty so callers can gate source creation.
+ */
+export function buildHighlightFeatureCollection(
+  features: SelectedFeature[],
+): GeoJSON.FeatureCollection | null {
+  if (features.length === 0) return null;
+  return {
+    type: 'FeatureCollection',
+    features: features.map((f) => ({
+      type: 'Feature' as const,
+      properties: f.properties,
+      geometry: f.geometry as unknown as GeoJSON.Geometry,
+    })),
+  };
+}

--- a/packages/map-ui-lib/src/utils/selection.ts
+++ b/packages/map-ui-lib/src/utils/selection.ts
@@ -9,8 +9,14 @@ export interface SelectedFeature {
   geometry: Record<string, unknown>;
 }
 
+function stableSerialize(obj: Record<string, unknown>): string {
+  const sorted: Record<string, unknown> = {};
+  for (const k of Object.keys(obj).sort()) sorted[k] = obj[k];
+  return JSON.stringify(sorted);
+}
+
 /** Build a unique key for a selected feature for deduplication. */
 export function selectedFeatureKey(feature: SelectedFeature): string {
   if (feature.id != null) return `${feature.layerId}:${feature.id}`;
-  return `${feature.layerId}:${JSON.stringify(feature.properties)}`;
+  return `${feature.layerId}:${stableSerialize(feature.properties)}`;
 }

--- a/packages/map-ui-lib/src/utils/wkt.ts
+++ b/packages/map-ui-lib/src/utils/wkt.ts
@@ -9,19 +9,23 @@ function ringToWkt(ring: Ring): string {
   return ring.map(coordToWkt).join(', ');
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function geojsonGeometryToWkt(geometry: any): string {
-  if (!geometry || !geometry.type) return '';
+/**
+ * Converts a GeoJSON geometry object to its WKT representation.
+ * Accepts the loose `Record<string, unknown>` shape used by OGC API responses
+ * so callers don't need an intermediate cast.
+ */
+export function geojsonGeometryToWkt(geometry: Record<string, unknown> | null | undefined): string {
+  if (!geometry?.type) return '';
 
   switch (geometry.type) {
     case 'Point':
-      return `POINT (${coordToWkt(geometry.coordinates)})`;
+      return `POINT (${coordToWkt(geometry.coordinates as Coord)})`;
 
     case 'MultiPoint':
       return `MULTIPOINT (${(geometry.coordinates as Coord[]).map((c) => `(${coordToWkt(c)})`).join(', ')})`;
 
     case 'LineString':
-      return `LINESTRING (${ringToWkt(geometry.coordinates)})`;
+      return `LINESTRING (${ringToWkt(geometry.coordinates as Ring)})`;
 
     case 'MultiLineString':
       return `MULTILINESTRING (${(geometry.coordinates as Ring[]).map((r) => `(${ringToWkt(r)})`).join(', ')})`;
@@ -33,7 +37,7 @@ export function geojsonGeometryToWkt(geometry: any): string {
       return `MULTIPOLYGON (${(geometry.coordinates as Ring[][]).map((poly) => `(${poly.map((r) => `(${ringToWkt(r)})`).join(', ')})`).join(', ')})`;
 
     case 'GeometryCollection':
-      return `GEOMETRYCOLLECTION (${(geometry.geometries as unknown[]).map(geojsonGeometryToWkt).join(', ')})`;
+      return `GEOMETRYCOLLECTION (${((geometry.geometries as Record<string, unknown>[]) ?? []).map(geojsonGeometryToWkt).join(', ')})`;
 
     default:
       return '';

--- a/packages/map-ui-lib/src/utils/wkt.ts
+++ b/packages/map-ui-lib/src/utils/wkt.ts
@@ -9,8 +9,13 @@ function ringToWkt(ring: Ring): string {
   return ring.map(coordToWkt).join(', ');
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function geojsonGeometryToWkt(geometry: any): string {
+type GeoJsonGeometry = {
+  type: string;
+  coordinates?: unknown;
+  geometries?: GeoJsonGeometry[];
+} | null | undefined;
+
+export function geojsonGeometryToWkt(geometry: GeoJsonGeometry): string {
   if (!geometry || !geometry.type) return '';
 
   switch (geometry.type) {


### PR DESCRIPTION
Integrates all 16 outstanding periodic-review PRs (#109–#174) into ai/main, with overlaps between the daily branches reconciled:

**Fixes**
- text-field accepts MapLibre expressions (#109, fixes #91)
- useMapSync: structural filter equality instead of JSON.stringify (#120)
- Abort in-flight OGC requests on unmount/dep change (#124, #158)
- Stable sorted-key feature dedup key (#140, #151, fixes #138)
- Pass source auth to useOgcQueryables/useOgcCollectionDetail (#172)
- Guard turfBuffer throw in sDwithin (#167); crypto guard in generateId (#164)
- geojsonGeometryToWkt + buildGeometryFilter type tightening (#151, #174, #141)

**Tests** (~350 new): spriteUtils, id/slugify/selection, boxDraw/colorThemes/colorPalettes, exportFormats, ogcApi signal+auth, uiStore, download, lintMapConfig edge cases

**CI**: map-client suite added; lib + admin-app coverage thresholds now enforced (#140, #141, #174)

**Refactors/docs**: selection helpers extracted (#150); deprecation docs (#157)

Conflict resolutions favored the newer abort style (AbortController, no `cancelled` flag) combined with auth params, and the sorted stable-serialize key. One follow-up fix: lintMapConfig test casts updated for the widened globalSearch schema.

Verified locally: `pnpm verify` (916 lib tests), lib coverage thresholds, admin-app `--coverage`, map-client, ingest-service — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)