### PR TITLE
test: add ingest-service db.ts unit coverage

### DIFF
--- a/apps/ingest-service/.gitignore
+++ b/apps/ingest-service/.gitignore
@@ -1,0 +1,1 @@
+coverage/

--- a/apps/ingest-service/src/db.test.ts
+++ b/apps/ingest-service/src/db.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Pool } from 'pg';
+import { collectTableStats, dropTable } from './db.js';
+
+function fakePool(rows: unknown[]): Pool {
+  return { query: vi.fn().mockResolvedValue({ rows }) } as unknown as Pool;
+}
+
+describe('collectTableStats', () => {
+  it('parses geometry type, srid, count, and bbox from the stats row', async () => {
+    const pool = fakePool([
+      { n: 42, gt: 'MULTIPOLYGON', srid: 4326, minx: -105.1, miny: 38.2, maxx: -104.9, maxy: 38.5 },
+    ]);
+    const stats = await collectTableStats(pool, 'parcels');
+    expect(stats).toEqual({
+      geometryType: 'MULTIPOLYGON',
+      srid: 4326,
+      featureCount: 42,
+      bbox: [-105.1, 38.2, -104.9, 38.5],
+    });
+  });
+
+  it('defaults srid to 4326 and bbox to null when the table has no rows with geometry', async () => {
+    const pool = fakePool([
+      { n: 0, gt: null, srid: null, minx: null, miny: null, maxx: null, maxy: null },
+    ]);
+    const stats = await collectTableStats(pool, 'empty_table');
+    expect(stats).toEqual({
+      geometryType: null,
+      srid: 4326,
+      featureCount: 0,
+      bbox: null,
+    });
+  });
+
+  it('queries the uploads-schema-qualified, double-quoted table name', async () => {
+    const pool = fakePool([{ n: 1, gt: 'POINT', srid: 4326, minx: 0, miny: 0, maxx: 0, maxy: 0 }]);
+    await collectTableStats(pool, 'my_table');
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('"uploads"."my_table"'));
+  });
+
+  it('rejects an unsafe table identifier before querying', async () => {
+    const pool = fakePool([]);
+    await expect(collectTableStats(pool, 'drop table users; --')).rejects.toThrow(
+      /unsafe identifier/,
+    );
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+});
+
+describe('dropTable', () => {
+  it('issues a DROP TABLE IF EXISTS against the qualified table', async () => {
+    const pool = fakePool([]);
+    await dropTable(pool, 'stale_upload');
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('DROP TABLE IF EXISTS "uploads"."stale_upload"'),
+    );
+  });
+
+  it('is a silent no-op for an unsafe identifier instead of throwing', async () => {
+    const pool = fakePool([]);
+    await expect(dropTable(pool, '"; DROP TABLE map_admin.map_configs; --')).resolves.toBeUndefined();
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ingest-service/vitest.config.ts
+++ b/apps/ingest-service/vitest.config.ts
@@ -10,8 +10,11 @@ export default defineConfig({
       exclude: ['src/**/*.test.ts', 'src/index.ts'],
       thresholds: {
         // Baselined against unit-test-reachable files (contract, formats, identifiers,
-        // ogr, semaphore, unzip). db.ts and ingest.ts are only covered by the
-        // integration suite (INGEST_INTEGRATION=1). Tighten as unit tests are added.
+        // db, ogr, semaphore, unzip). ingest.ts (ingestFile/inspectSource) is only
+        // covered by the integration suite (INGEST_INTEGRATION=1). Actuals as of the
+        // db.ts unit tests are ~53.5% statements/lines — below the thresholds below —
+        // because this config isn't wired into CI (see issue for tracking); tighten
+        // both the CI wiring and these numbers as more of ingest.ts gets unit-tested.
         statements: 55,
         branches: 45,
         functions: 55,


### PR DESCRIPTION
## Summary

Periodic quality-review pass. Cross-checked against the 74 currently-open issues and 11 open PRs to avoid duplicating in-flight work (in particular #189's still-open findings and #190/#191's recommendation to focus on ingest-service/hook-level coverage next).

- **`apps/ingest-service/src/db.ts`** — `collectTableStats`/`dropTable` had zero unit coverage (only reachable via the live-PostGIS integration suite). Added `db.test.ts` with a mocked `Pool`: normal stats parsing, null-row/empty-table defaults (srid 4326, bbox null), the schema-qualified query shape, and the `isValidIdentifier` defense-in-depth guard on both functions (rejects unsafe table names before any query is issued). This is the smaller half of #190 — `ingestFile`/`inspectSource` in `ingest.ts` still need call-shape mocking (`execFile`, `fs`) and are left for a follow-up.
- **`apps/ingest-service/vitest.config.ts`** — updated the threshold comment: db.ts is now unit-tested; `ingest.ts` remains integration-only. Also noted that current actuals (~53.5% statements/lines) are still below the configured 55% threshold, and that this is invisible today because CI runs `pnpm --filter ingest-service test` rather than `test:coverage` (filed as a follow-up issue below).
- **`apps/ingest-service/.gitignore`** — sidecar was the only workspace without a `coverage/` ignore (lib, admin-app, and map-client all have one); added for consistency, since `pnpm test:coverage` now produces one locally.

## Filed separately (larger effort / distinct concern)

- CI doesn't run `test:coverage` for `ingest-service` (or `map-client`), so the sidecar's own coverage thresholds can silently regress or (as found here) already sit below target with no signal — analogous to #135/#142 but for this workspace. See the linked issue for detail.

## Test plan

- [x] `pnpm verify` (lib build + test, 916 tests)
- [x] `cd apps/map-client && pnpm exec vitest run` (53 tests)
- [x] `cd apps/admin-app && pnpm exec vitest run` (212 tests)
- [x] `cd apps/ingest-service && pnpm exec vitest run` (70 tests, incl. 6 new)
- [x] `pnpm build` (full monorepo, all apps + lib)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XZnfqLGmpr5tuksbxtCmnB)_