### PR TITLE
fix: dashByCategory id collisions, docs type-check, geomField validation

### DIFF
--- a/apps/ingest-service/src/index.ts
+++ b/apps/ingest-service/src/index.ts
@@ -84,10 +84,15 @@ app.post('/layers', upload.single('file'), async (req, res) => {
   let srcPath = req.file.path;
   try {
     const requested = (field(req, 'format') ?? 'auto') as FormatId | 'auto';
+    const geomField = field(req, 'geomField');
+    if (geomField && !isValidGeomField(geomField)) {
+      res.status(400).json({ error: 'invalid geomField (expected a column name)' });
+      return;
+    }
     const head = await readHead(srcPath);
     const format = resolveFormat(requested, req.file.originalname, head); // validate type
     srcPath = await ensureExtension(srcPath, format);
-    const { layers } = await inspectSource(srcPath, { format, geomField: field(req, 'geomField') });
+    const { layers } = await inspectSource(srcPath, { format, geomField });
     res.json({ layers });
   } catch (err) {
     res.status(400).json({ error: (err as Error).message });

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -650,9 +650,9 @@ if (result.success) {
 Based on the reference app (`apps/map-client/src/config/map-config.ts`):
 
 ```ts
-import type { MapConfig } from '@ogc-maps/storybook-components/types';
+import type { MapConfigInput } from '@ogc-maps/storybook-components/types';
 
-export const mapConfig: MapConfig = {
+export const mapConfig: MapConfigInput = {
   sources: [
     {
       id: 'tipg-local',
@@ -669,10 +669,12 @@ export const mapConfig: MapConfig = {
       label: 'Countries',
       visible: true,
       dataMode: 'vector-tiles',
-      style: {
-        type: 'fill',
-        paint: { 'fill-color': '#4a90d9', 'fill-opacity': 0.6, 'fill-outline-color': '#2c5f8a' },
-      },
+      styles: [
+        {
+          type: 'fill',
+          paint: { 'fill-color': '#4a90d9', 'fill-opacity': 0.6, 'fill-outline-color': '#2c5f8a' },
+        },
+      ],
       legend: {
         entries: [{ label: 'Countries', color: '#4a90d9', shape: 'square' }],
       },
@@ -692,10 +694,12 @@ export const mapConfig: MapConfig = {
       label: 'Cities',
       visible: true,
       dataMode: 'geojson',
-      style: {
-        type: 'circle',
-        paint: { 'circle-color': '#e74c3c', 'circle-radius': 5, 'circle-opacity': 0.9, 'circle-stroke-color': '#ffffff', 'circle-stroke-width': 1 },
-      },
+      styles: [
+        {
+          type: 'circle',
+          paint: { 'circle-color': '#e74c3c', 'circle-radius': 5, 'circle-opacity': 0.9, 'circle-stroke-color': '#ffffff', 'circle-stroke-width': 1 },
+        },
+      ],
       legend: {
         entries: [{ label: 'Cities', color: '#e74c3c', shape: 'circle' }],
       },
@@ -707,10 +711,12 @@ export const mapConfig: MapConfig = {
       label: 'Rivers',
       visible: true,
       dataMode: 'vector-tiles',
-      style: {
-        type: 'line',
-        paint: { 'line-color': '#00bcd4', 'line-width': 2, 'line-opacity': 0.8 },
-      },
+      styles: [
+        {
+          type: 'line',
+          paint: { 'line-color': '#00bcd4', 'line-width': 2, 'line-opacity': 0.8 },
+        },
+      ],
       legend: {
         entries: [{ label: 'Rivers', color: '#00bcd4', shape: 'line' }],
       },

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -33,9 +33,9 @@ The library uses TailwindCSS v4 with a `mapui:` prefix — all styles are scoped
 Create a config object that satisfies `MapConfig`. At minimum you need one source, one basemap, and an `initialView`:
 
 ```ts
-import type { MapConfig } from '@ogc-maps/storybook-components/types';
+import type { MapConfigInput } from '@ogc-maps/storybook-components/types';
 
-export const mapConfig: MapConfig = {
+export const mapConfig: MapConfigInput = {
   sources: [
     {
       id: 'my-api',
@@ -51,10 +51,12 @@ export const mapConfig: MapConfig = {
       label: 'Countries',
       visible: true,
       dataMode: 'vector-tiles',
-      style: {
-        type: 'fill',
-        paint: { 'fill-color': '#4a90d9', 'fill-opacity': 0.6 },
-      },
+      styles: [
+        {
+          type: 'fill',
+          paint: { 'fill-color': '#4a90d9', 'fill-opacity': 0.6 },
+        },
+      ],
     },
   ],
   basemaps: [
@@ -71,6 +73,8 @@ export const mapConfig: MapConfig = {
   },
 };
 ```
+
+> `MapConfigInput` is the pre-validation shape — fields with schema defaults (like `ui` or `initialView.pitch`/`bearing`) are optional here. Run it through `validateMapConfig`/`safeValidateMapConfig` (below) to get a fully-defaulted `MapConfig`.
 
 ## Validate the Config
 

--- a/docs/SEARCH-INTEGRATION.md
+++ b/docs/SEARCH-INTEGRATION.md
@@ -42,9 +42,9 @@ MapConfig.layers[].search.fields
 Add a `search` config to each layer in your `MapConfig`:
 
 ```ts
-import type { MapConfig } from '@ogc-maps/storybook-components/types';
+import type { MapConfigInput } from '@ogc-maps/storybook-components/types';
 
-const mapConfig: MapConfig = {
+const mapConfig: MapConfigInput = {
   // ... sources, basemaps, initialView ...
   layers: [
     {
@@ -54,7 +54,7 @@ const mapConfig: MapConfig = {
       label: 'Countries',
       visible: true,
       dataMode: 'vector-tiles',
-      style: { type: 'fill', paint: { 'fill-color': '#4a90d9', 'fill-opacity': 0.6 } },
+      styles: [{ type: 'fill', paint: { 'fill-color': '#4a90d9', 'fill-opacity': 0.6 } }],
       search: {
         fields: [
           // Text with autocomplete

--- a/packages/map-ui-lib/src/types/index.ts
+++ b/packages/map-ui-lib/src/types/index.ts
@@ -172,6 +172,16 @@ export type BrandingConfig = z.infer<typeof BrandingConfigSchema>;
 export type InfoConfig = z.infer<typeof InfoConfigSchema>;
 export type { InfoPosition } from '../schemas/config';
 export type MapConfig = z.infer<typeof MapConfigSchema>;
+/**
+ * Pre-validation shape for hand-authored config literals. `MapConfig` is the
+ * post-`.parse()` output type, so every field with a Zod `.default()` (e.g.
+ * `layers[].styles`'s legacy `style` alias, `ui`, `initialView.pitch`) is
+ * required on it even though the schema fills it in at parse time. Annotate
+ * literals you intend to pass through `validateMapConfig`/
+ * `safeValidateMapConfig` as `MapConfigInput` instead so those fields stay
+ * optional; use `MapConfig` for values you already know are parsed.
+ */
+export type MapConfigInput = z.input<typeof MapConfigSchema>;
 
 /** Callback for fetching distinct property values from an OGC API collection. */
 export type FetchDistinctValuesFn = (

--- a/packages/map-ui-lib/src/utils/__tests__/dashByCategory.test.ts
+++ b/packages/map-ui-lib/src/utils/__tests__/dashByCategory.test.ts
@@ -161,4 +161,42 @@ describe('expandDashByCategory', () => {
     // The filter still uses the original value, not the slug
     expect(result[0].filter).toEqual(['==', ['get', 'route'], 'US Hwy 50']);
   });
+
+  it('dedupes idSuffix when distinct case values slugify to the same string', () => {
+    const style: LineStyle = {
+      ...baseLineStyle,
+      dashByCategory: {
+        property: 'route',
+        cases: [
+          { value: 'US Hwy 50', dasharray: [1, 0] },
+          { value: 'US-Hwy-50', dasharray: [4, 2] },
+        ],
+      },
+    };
+    const result = expandDashByCategory(style);
+    const ids = result.map((r) => r.idSuffix);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(['dash--US_Hwy_50', 'dash--US_Hwy_50-2']);
+    // Filters still discriminate on the original, un-slugified values.
+    expect(result[0].filter).toEqual(['==', ['get', 'route'], 'US Hwy 50']);
+    expect(result[1].filter).toEqual(['==', ['get', 'route'], 'US-Hwy-50']);
+  });
+
+  it('dedupes idSuffix when a case value literally slugifies to "default"', () => {
+    const style: LineStyle = {
+      ...baseLineStyle,
+      dashByCategory: {
+        property: 'class',
+        cases: [{ value: 'default', dasharray: [1, 0] }],
+        default: [4, 4],
+      },
+    };
+    const result = expandDashByCategory(style);
+    const ids = result.map((r) => r.idSuffix);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(['dash--default', 'dash--default-2']);
+    // The case layer (not the default layer) keeps the un-suffixed id.
+    expect(result[0].value).toBe('default');
+    expect(result[1].value).toBeNull();
+  });
 });

--- a/packages/map-ui-lib/src/utils/dashByCategory.ts
+++ b/packages/map-ui-lib/src/utils/dashByCategory.ts
@@ -54,12 +54,33 @@ export function slugifyDashCaseValue(v: string | number): string {
  * `dashByCategory` (callers should fall back to rendering a single layer
  * with the original paint).
  */
+/**
+ * Reserve a unique `idSuffix`, appending `-2`, `-3`, ... on collision. Distinct
+ * case values can slugify to the same string (e.g. `"US Hwy 50"` and
+ * `"US-Hwy-50"` both become `US_Hwy_50`), and a case value can even collide
+ * with the literal `dash--default` suffix reserved for the default-case
+ * layer. MapLibre requires unique `<Layer>` ids, so an unresolved collision
+ * means the second layer silently fails to render.
+ */
+function reserveSuffix(seen: Set<string>, base: string): string {
+  if (!seen.has(base)) {
+    seen.add(base);
+    return base;
+  }
+  let i = 2;
+  while (seen.has(`${base}-${i}`)) i++;
+  const suffix = `${base}-${i}`;
+  seen.add(suffix);
+  return suffix;
+}
+
 export function expandDashByCategory(style: LineStyle): ExpandedDashSubLayer[] {
   const cfg: DashByCategory | undefined = style.dashByCategory;
   if (!cfg || !cfg.cases.length) return [];
 
+  const usedSuffixes = new Set<string>();
   const out: ExpandedDashSubLayer[] = cfg.cases.map((c) => ({
-    idSuffix: `dash--${slugifyDashCaseValue(c.value)}`,
+    idSuffix: reserveSuffix(usedSuffixes, `dash--${slugifyDashCaseValue(c.value)}`),
     dasharray: c.dasharray,
     filter: ['==', ['get', cfg.property], c.value],
     label: String(c.value),
@@ -86,7 +107,7 @@ export function expandDashByCategory(style: LineStyle): ExpandedDashSubLayer[] {
       ['all', ...caseValues.map((v) => ['!=', ['get', cfg.property], v])],
     ];
     out.push({
-      idSuffix: 'dash--default',
+      idSuffix: reserveSuffix(usedSuffixes, 'dash--default'),
       dasharray: cfg.default,
       filter: negatedFilter,
       label: '',


### PR DESCRIPTION
## Summary

Periodic quality-review pass (2026-07-08). Cross-checked against the 75 currently-open issues and open PRs (#189, #193 pending merge) to avoid duplicating in-flight work; these are net-new, low-risk findings.

- **`packages/map-ui-lib/src/utils/dashByCategory.ts`** — `expandDashByCategory` derived each sub-layer's MapLibre `<Layer>` id suffix from `slugifyDashCaseValue(value)`, with no collision handling. Two distinct case values that slugify to the same string (e.g. `"US Hwy 50"` vs `"US-Hwy-50"`, both → `US_Hwy_50`), or a case value that's literally `"default"` colliding with the reserved default-case suffix, produce duplicate layer ids. MapLibre silently drops/ignores a layer with a duplicate id, so that category's dasharray never renders. Added a `reserveSuffix` dedup helper (appends `-2`, `-3`, ...) and two regression tests covering both collision shapes.
- **`packages/map-ui-lib/src/types/index.ts` + `docs/GETTING-STARTED.md`, `docs/CONFIGURATION.md`, `docs/SEARCH-INTEGRATION.md`** — all three docs' `MapConfig`-typed literal examples fail `tsc --noEmit` today (verified). Two separate causes: (1) `style: {...}` should be `styles: [...]` — `LayerConfigSchema` only has a runtime back-compat shim for the legacy singular `style`, it isn't reflected in the type; (2) every schema field with a Zod `.default()` (`initialView.pitch`/`bearing`, `sources[].tileMatrixSetId`, the entire `ui` block — ~19 fields) is *required* on `MapConfig` (the post-parse output type) even though the schema fills it in at parse time, so hand-authored literals need everything spelled out. Rather than patch each doc with an increasingly long field list (fragile against future schema changes), added `MapConfigInput = z.input<typeof MapConfigSchema>` following the exact precedent already in this file (`PropertyDisplayConfigInput`), and pointed all three docs' literal examples at it. Verified all three now compile clean via `tsc --noEmit`.
- **`apps/ingest-service/src/index.ts`** — the `/layers` preflight route passed client-supplied `geomField` straight to `inspectSource` unvalidated, while `/ingest` (which `/layers` is supposed to preflight for) validates it with `isValidGeomField` first. Not a demonstrated exploit (goes into `ogrinfo` via `execFile` argv, not a shell), but an inconsistent validation boundary between two routes sharing the same code path. Now `/layers` validates the same way `/ingest` does.

## Not fixed here (filed separately)

- Dependency backlog: issue #106 (stale — references superseded PR numbers) commented with current state: 6 dependabot PRs open, oldest (maplibre-gl runtime bump, flatgeobuf) now 50+ days old with GitHub auto-rebase disabled.
- See the periodic-review summary issue for the full list of what was checked and ruled out this pass.

## Test plan

- [x] `pnpm verify` (lib build + test, 918 tests incl. 2 new)
- [x] `cd apps/admin-app && pnpm exec vitest run --coverage` (unchanged, all pass)
- [x] `cd apps/map-client && pnpm exec vitest run --coverage` (unchanged, all pass)
- [x] `pnpm --filter ingest-service test` (64 tests, all pass)
- [x] `pnpm build` (full monorepo, all workspaces)
- [x] Manually verified all three doc examples compile via `tsc --noEmit` before and after the fix (repro'd the failure, confirmed the fix)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RqD2ok1gtL9vMLesaT1sbd)_