### PR TITLE
fix: shapefile .prj basename matching, project-label-sync case+pagination bugs

### DIFF
--- a/.github/workflows/project-label-sync.yml
+++ b/.github/workflows/project-label-sync.yml
@@ -36,16 +36,17 @@ jobs:
             const statusToLabel = {
               'Clarify': 'status:clarify',
               'Ready': 'status:ready',
-              'In progress': 'status:in-progress',
-              'In review': 'status:in-review',
+              'In Progress': 'status:in-progress',
+              'In Review': 'status:in-review',
             };
             const allStatusLabels = Object.values(statusToLabel);
 
             // Fetch project items with their Status field and linked content
-            const query = `query($org: String!, $number: Int!) {
+            const query = `query($org: String!, $number: Int!, $after: String) {
               organization(login: $org) {
                 projectV2(number: $number) {
-                  items(first: 100) {
+                  items(first: 100, after: $after) {
+                    pageInfo { hasNextPage endCursor }
                     nodes {
                       fieldValueByName(name: "Status") {
                         ... on ProjectV2ItemFieldSingleSelectValue { name }
@@ -72,21 +73,29 @@ jobs:
               }
             }`;
 
-            const result = await github.graphql(query, {
-              org: process.env.ORG,
-              number: parseInt(process.env.PROJECT_NUMBER),
-            });
+            const items = [];
+            let after = null;
+            let hasNextPage = true;
+            while (hasNextPage) {
+              const result = await github.graphql(query, {
+                org: process.env.ORG,
+                number: parseInt(process.env.PROJECT_NUMBER),
+                after,
+              });
 
-            const project = result?.organization?.projectV2;
-            if (!project) {
-              core.setFailed(
-                `projectV2(number: ${process.env.PROJECT_NUMBER}) returned null for org ${process.env.ORG}. ` +
-                `Check that PROJECT_TOKEN has 'read:project' scope and the project exists.`
-              );
-              return;
+              const project = result?.organization?.projectV2;
+              if (!project) {
+                core.setFailed(
+                  `projectV2(number: ${process.env.PROJECT_NUMBER}) returned null for org ${process.env.ORG}. ` +
+                  `Check that PROJECT_TOKEN has 'read:project' scope and the project exists.`
+                );
+                return;
+              }
+
+              items.push(...project.items.nodes);
+              hasNextPage = project.items.pageInfo.hasNextPage;
+              after = project.items.pageInfo.endCursor;
             }
-
-            const items = project.items.nodes;
 
             for (const item of items) {
               const content = item.content;

--- a/apps/ingest-service/src/unzip.test.ts
+++ b/apps/ingest-service/src/unzip.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { isSafeZipEntry, isShapefileSidecar } from './unzip.js';
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { isSafeZipEntry, isShapefileSidecar, extractShapefileZip } from './unzip.js';
 
 const dest = '/tmp/ingest-abc';
 
@@ -35,5 +39,63 @@ describe('isShapefileSidecar', () => {
     expect(isShapefileSidecar('readme.txt')).toBe(false);
     expect(isShapefileSidecar('evil.exe')).toBe(false);
     expect(isShapefileSidecar('nested.zip')).toBe(false);
+  });
+});
+
+describe('extractShapefileZip (.prj basename matching)', () => {
+  const tmpDirs: string[] = [];
+  afterEach(() => {
+    for (const d of tmpDirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  function buildZip(files: Record<string, string>): { zipPath: string; destDir: string } {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unzip-test-'));
+    const destDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unzip-dest-'));
+    tmpDirs.push(workDir, destDir);
+    const paths = Object.entries(files).map(([name, content]) => {
+      const p = path.join(workDir, name);
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, content);
+      return p;
+    });
+    const zipPath = path.join(workDir, 'bundle.zip');
+    execFileSync('zip', ['-j', zipPath, ...paths], { stdio: 'pipe' });
+    return { zipPath, destDir };
+  }
+
+  it('reports hasPrj=true when the .prj basename matches the .shp', async () => {
+    const { zipPath, destDir } = buildZip({
+      'parcels.shp': 'shp',
+      'parcels.shx': 'shx',
+      'parcels.dbf': 'dbf',
+      'parcels.prj': 'GEOGCS[...]',
+    });
+    const result = await extractShapefileZip(zipPath, destDir);
+    expect(result.hasPrj).toBe(true);
+  });
+
+  it('reports hasPrj=false when a .prj is present but its basename does not match the .shp', async () => {
+    // Simulates a leftover/unrelated .prj bundled alongside the shapefile —
+    // GDAL only associates a .prj with a .shp of the same basename, so a
+    // mismatched one should not be treated as a declared CRS.
+    const { zipPath, destDir } = buildZip({
+      'parcels.shp': 'shp',
+      'parcels.shx': 'shx',
+      'parcels.dbf': 'dbf',
+      'old_export/backup.prj': 'GEOGCS[...]',
+    });
+    const result = await extractShapefileZip(zipPath, destDir);
+    expect(result.hasPrj).toBe(false);
+  });
+
+  it('matches basenames case-insensitively', async () => {
+    const { zipPath, destDir } = buildZip({
+      'Parcels.shp': 'shp',
+      'Parcels.shx': 'shx',
+      'Parcels.dbf': 'dbf',
+      'PARCELS.PRJ': 'GEOGCS[...]',
+    });
+    const result = await extractShapefileZip(zipPath, destDir);
+    expect(result.hasPrj).toBe(true);
   });
 });

--- a/apps/ingest-service/src/unzip.ts
+++ b/apps/ingest-service/src/unzip.ts
@@ -66,7 +66,7 @@ export function extractShapefileZip(
       let totalBytes = 0;
       let entryCount = 0;
       const shpFiles: string[] = [];
-      let hasPrj = false;
+      const prjStems: string[] = [];
       let settled = false;
 
       const fail = (e: Error) => {
@@ -86,6 +86,12 @@ export function extractShapefileZip(
         } else if (shpFiles.length > 1) {
           reject(new Error(`Zip contains multiple shapefiles (${shpFiles.length}); upload one at a time`));
         } else {
+          // GDAL only picks up a .prj that shares the .shp's basename in the
+          // same directory (all sidecars are flattened into destDir above).
+          // A .prj present elsewhere in the zip under an unrelated name would
+          // never actually be found by GDAL, so only count it if it matches.
+          const shpStem = path.basename(shpFiles[0], path.extname(shpFiles[0])).toLowerCase();
+          const hasPrj = prjStems.includes(shpStem);
           resolve({ shpPath: shpFiles[0], hasPrj });
         }
       });
@@ -133,7 +139,7 @@ export function extractShapefileZip(
 
         const outPath = path.join(destDir, path.basename(name));
         if (ext === '.shp') shpFiles.push(outPath);
-        if (ext === '.prj') hasPrj = true;
+        if (ext === '.prj') prjStems.push(path.basename(name, path.extname(name)).toLowerCase());
 
         zipfile.openReadStream(entry, (streamErr, readStream) => {
           if (streamErr || !readStream) {


### PR DESCRIPTION
## Summary

Periodic quality-review pass (2026-07-09). Cross-checked against the 76 currently-open issues to avoid duplicating in-flight work; these are net-new, low-risk findings verified against source before fixing.

- **`apps/ingest-service/src/unzip.ts`** (`extractShapefileZip`) — `hasPrj` was set `true` for *any* `.prj` entry anywhere in the zip, regardless of whether its basename matched the `.shp`. GDAL's shapefile driver only associates a `.prj` with a `.shp` of the exact same basename in the same directory (all sidecars get flattened into one dir here). So a zip containing `parcels.shp/.shx/.dbf` plus an unrelated leftover `.prj` (different basename) set `hasPrj = true`, but GDAL would never actually find a CRS for `parcels.shp` — `ogr.ts` then skips `-s_srs EPSG:4326` believing a CRS was declared, GDAL falls back to an undefined default, and `crsAssumed` is reported `false` to the admin UI even though the projection was effectively unknown/assumed. Now tracks `.prj` basenames (case-insensitively) and only counts a match against the resolved `.shp`'s basename. Added 3 regression tests (`unzip.test.ts`): matching basename, mismatched/unrelated `.prj`, and case-insensitive matching — using the same `zip` CLI fixture-building approach already established in `ingest.integration.test.ts`.
- **`.github/workflows/project-label-sync.yml`** — two bugs in the Project-board → label sync script:
  1. `statusToLabel` map used sentence-case keys (`'In progress'`, `'In review'`) while the file's own header comment and `docs/GITHUB_PIPELINE.md`'s documented board columns are Title Case (`'In Progress'`, `'In Review'`). Since GitHub Projects V2 Status field option names come from the actual column names, any item whose Status is genuinely "In Progress" or "In Review" got `expectedLabel = undefined` — and worse, the "remove stale status labels" loop then **stripped** any existing `status:in-progress`/`status:in-review` label every run (since `label !== undefined` is always true), while the "add correct label" branch never re-added it. These two pipeline stages were actively losing their labels on every 5-minute run rather than gaining them.
  2. `items(first: 100)` had no pagination — once the org's project board holds more than 100 items (this repo alone has 76+ open issues), anything past the first page was silently never synced, with no error or log signal. Added a `while (hasNextPage)` loop using `pageInfo { hasNextPage endCursor }`.

## Not fixed here (filed separately)

- `.github/workflows/claude.yml` has no `labeled` trigger at all (and no label-based `if:` condition), even though `docs/GITHUB_PIPELINE.md` documents "Apply a label to an issue or PR. The workflow fires automatically" as one of three equivalent trigger mechanisms. This is a real doc/implementation gap, but fixing it requires a design decision (which labels should trigger, what prompt/mode each maps to, and how to avoid double-triggering against this same `project-label-sync.yml`), so it's filed as an issue rather than fixed here.
- Dependency backlog (#106) unchanged this pass — still out of scope per CLAUDE.md (major bumps held for manual review).

## Also this pass: merged 3 previously-stalled review PRs

Before this pass, PRs #189 (2026-07-06), #193 (2026-07-07), and #195 (2026-07-08) were all still open, draft, verified, and `mergeable_state: clean` against `ai/main` — a gap prior review passes (#192, #196) repeatedly flagged but didn't act on. Per CLAUDE.md's solo-task workflow (AI may merge verified worktree branches into `ai/main` freely), merged all three in chronological order with `pnpm verify` + full app-suite runs between each merge, then pushed. All three PRs are now closed as merged; CI on `ai/main` is green post-merge.

## Test plan

- [x] `pnpm --filter ingest-service test` (73 tests, incl. 3 new `unzip.test.ts` regression tests)
- [x] `pnpm --filter ingest-service build` (tsc, clean)
- [x] `pnpm verify` (lib build + test, 918 tests)
- [x] YAML syntax of `project-label-sync.yml` validated
- [x] `git push` of the merged `ai/main` (containing #189/#193/#195) triggered CI on GitHub — completed `success`


---
_Generated by [Claude Code](https://claude.ai/code/session_014rq4V3JCzojx8D8hyQBvRs)_